### PR TITLE
Update cicd

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,15 +12,13 @@ __pycache__/
 .gitignore
 .gitattributes
 
-# Poetry
-pyproject.toml
-poetry.lock
+# Lock files (pyproject.toml is required for pip install in the image)
+uv.lock
 
 # Pre-commit
 .pre-commit-config.yaml
 
 # Documentation
-README.md
 *.md
 
 # GitHub

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -10,6 +10,8 @@ env:
   IMAGE_NAME: ${{ vars.IMAGE_NAME }}
   CLOUD_RUN_SERVICE: ${{ vars.CLOUD_RUN_SERVICE }}
   SERVER_URL: ${{ vars.SERVER_URL }}
+  VECTOR_STORE_CONFIG_ID: ${{ vars.VECTOR_STORE_CONFIG_ID }}
+  OPENAI_MODEL: ${{ vars.OPENAI_MODEL }}
 
 jobs:
   build-and-deploy:
@@ -32,37 +34,46 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
 
-      # Step 4: Export dependencies to requirements.txt
+      # Step 4: Install dependencies (dev group includes alembic and modal)
+      - name: Install project dependencies
+        run: uv sync --group dev
+
+      # Step 5: Run database migrations (direct connection; idempotent)
+      - name: Run database migrations
+        env:
+          DATABASE_URL_DIRECT: ${{ secrets.DATABASE_URL_DIRECT }}
+        run: uv run alembic upgrade head
+
+      # Step 6: Deploy Modal app (pooled connection injected at deploy time)
+      - name: Deploy to Modal
+        env:
+          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+          DATABASE_URL_POOLED: ${{ secrets.DATABASE_URL_POOLED }}
+        run: uv run modal deploy backend/server.py
+
+      # Step 7: Export dependencies to requirements.txt
       - name: Export requirements from uv
         run: |
           uv export --no-dev --no-hashes --output-file requirements.txt
           echo "Generated requirements.txt:"
           cat requirements.txt
 
-      # Step 5: Deploy Modal app
-      - name: Deploy to Modal
-        env:
-          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
-          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
-        run: |
-          pip install modal
-          modal deploy modal_server.py
-
-      # Step 6: Authenticate to Google Cloud
+      # Step 8: Authenticate to Google Cloud
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
-      # Step 7: Set up Cloud SDK
+      # Step 9: Set up Cloud SDK
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
 
-      # Step 8: Configure Docker to use Artifact Registry
+      # Step 10: Configure Docker to use Artifact Registry
       - name: Configure Docker for Artifact Registry
         run: gcloud auth configure-docker ${{ env.GAR_LOCATION }}-docker.pkg.dev --quiet
 
-      # Step 9: Generate Docker image tags (outputs full image references, not just tag names)
+      # Step 11: Generate Docker image tags (outputs full image references, not just tag names)
       # Example output: us-central1-docker.pkg.dev/PROJECT/REPO/IMAGE:TAG
       # Creates 3 tags:
       #   1. Commit SHA (e.g., main-abc123) - for pinning to specific commits
@@ -78,7 +89,7 @@ jobs:
             type=ref,event=branch
             type=raw,value=latest,enable={{is_default_branch}}
 
-      # Step 10: Build and push Docker image to Artifact Registry
+      # Step 12: Build and push Docker image to Artifact Registry
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
@@ -87,7 +98,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
-      # Step 11: Deploy to Cloud Run
+      # Step 13: Deploy to Cloud Run
       - name: Deploy to Cloud Run
         uses: google-github-actions/deploy-cloudrun@v2
         with:
@@ -105,3 +116,5 @@ jobs:
           env_vars: |
             SERVER_URL=${{ env.SERVER_URL }}
             OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}
+            OPENAI_MODEL=${{ env.OPENAI_MODEL }}
+            VECTOR_STORE_CONFIG_ID=${{ env.VECTOR_STORE_CONFIG_ID }}

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -10,7 +10,6 @@ env:
   IMAGE_NAME: ${{ vars.IMAGE_NAME }}
   CLOUD_RUN_SERVICE: ${{ vars.CLOUD_RUN_SERVICE }}
   SERVER_URL: ${{ vars.SERVER_URL }}
-  VECTOR_STORE_CONFIG_ID: ${{ vars.VECTOR_STORE_CONFIG_ID }}
   OPENAI_MODEL: ${{ vars.OPENAI_MODEL }}
 
 jobs:
@@ -117,4 +116,3 @@ jobs:
             SERVER_URL=${{ env.SERVER_URL }}
             OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}
             OPENAI_MODEL=${{ env.OPENAI_MODEL }}
-            VECTOR_STORE_CONFIG_ID=${{ env.VECTOR_STORE_CONFIG_ID }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,21 +2,21 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
-# Copy requirements and install dependencies
-COPY requirements.txt .
+# requirements.txt is generated in CI (see .github/workflows/build-and-deploy.yml).
+# It lists third-party deps and includes `-e .`, which installs this repo as a package.
+# For `-e .` to succeed, frontend/, backend/, and db/ must already be copied into the image.
+# pyproject.toml is required by `-e .` (defines packages: frontend, backend, db).
+COPY requirements.txt pyproject.toml ./
+COPY frontend/ frontend/
+COPY backend/ backend/
+COPY db/ db/
 RUN pip install --no-cache-dir -r requirements.txt
-# NOTE: requirements.txt is generated during the CI/CD workflow.
-# This keeps dependencies in sync without manual duplication.
-# See .github/workflows/build-and-deploy.yml.
-
-# Copy necessary application files (vector store now runs on Modal)
-COPY app.py backend.py ./
 
 # Expose port 8080 for Cloud Run
 EXPOSE 8080
 
 # Run Streamlit with Cloud Run-compatible settings
-CMD ["streamlit", "run", "app.py", \
+CMD ["streamlit", "run", "frontend/app.py", \
      "--server.port=8080", \
      "--server.address=0.0.0.0", \
      "--server.headless=true", \

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -20,7 +20,6 @@ class RetrievedChunk(BaseModel):
 
 class RetrieveRequest(BaseModel):
     query: str
-    vector_store_config_id: int
     top_k: int
     source: str | None = None
 

--- a/backend/server.py
+++ b/backend/server.py
@@ -16,6 +16,7 @@ SENTENCE_TRANSFORMER_PATH = (
     "/data/weights/sentence-transformers_all-MiniLM-L6-v2"
 )
 CROSS_ENCODER_PATH = "/data/weights/cross-encoder_ms-marco-MiniLM-L-6-v2"
+VECTOR_STORE_CONFIG_ID = 1
 
 # The runtime queries Postgres through the pooled connection. The value is read
 # from the deploy environment (GitHub secrets in CI, .env locally) and injected
@@ -82,7 +83,7 @@ class Server:
                 return retrieve(
                     session=session,
                     embedder=self.embedder,
-                    vector_store_config_id=request.vector_store_config_id,
+                    vector_store_config_id=VECTOR_STORE_CONFIG_ID,
                     query=request.query,
                     top_k=request.top_k,
                     source=request.source,

--- a/frontend/client.py
+++ b/frontend/client.py
@@ -89,7 +89,7 @@ class RAGClient:
         response = self.openai_client.responses.create(
             model=OPENAI_MODEL,
             input=prompt,
-            reasoning={"effort": "minimal"},
+            reasoning={"effort": "low"},
         )
         return response.output[1].content[0].text
 

--- a/frontend/client.py
+++ b/frontend/client.py
@@ -12,7 +12,7 @@ load_dotenv()
 API_KEY = os.environ["OPENAI_API_KEY"]
 SERVER_URL = os.environ["SERVER_URL"]
 VECTOR_STORE_CONFIG_ID = int(os.environ["VECTOR_STORE_CONFIG_ID"])
-OPENAI_MODEL = "gpt-5-mini-2025-08-07"
+OPENAI_MODEL = os.environ["OPENAI_MODEL"]
 PROMPT_TEMPLATE = """
 # ROLE
 You are a skilled question-answering assistant.

--- a/frontend/client.py
+++ b/frontend/client.py
@@ -117,6 +117,3 @@ class RAGClient:
         )
         answer = self.ping_openai(prompt)
         return answer, top_chunks
-
-
-# TODO: Rename this module to rag_client.py?

--- a/frontend/client.py
+++ b/frontend/client.py
@@ -11,7 +11,6 @@ load_dotenv()
 
 API_KEY = os.environ["OPENAI_API_KEY"]
 SERVER_URL = os.environ["SERVER_URL"]
-VECTOR_STORE_CONFIG_ID = int(os.environ["VECTOR_STORE_CONFIG_ID"])
 OPENAI_MODEL = os.environ["OPENAI_MODEL"]
 PROMPT_TEMPLATE = """
 # ROLE
@@ -52,14 +51,12 @@ class RAGClient:
         self,
         query: str,
         top_k: int,
-        vector_store_config_id: int,
         source: str | None = None,
     ) -> list[RetrievedChunk]:
         response = self.http_client.post(
             "/retrieve",
             json={
                 "query": query,
-                "vector_store_config_id": vector_store_config_id,
                 "top_k": top_k,
                 "source": source,
             },
@@ -99,7 +96,6 @@ class RAGClient:
     def ask(
         self,
         query: str,
-        vector_store_config_id: int = VECTOR_STORE_CONFIG_ID,
         source: str | None = None,
         top_k_retrieval: int = 100,
         top_k_rerank: int = 20,
@@ -107,7 +103,6 @@ class RAGClient:
         chunks = self.retrieve(
             query=query,
             top_k=top_k_retrieval,
-            vector_store_config_id=vector_store_config_id,
             source=source,
         )
         top_chunks = self.rerank(query, chunks, top_k_rerank)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ build-backend = "hatchling.build"
 name = "presidents-rag"
 version = "0.1.0"
 description = ""
-readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "httpx>=0.28.1",


### PR DESCRIPTION
## Summary

Updates CI/CD and the frontend Docker image for the `backend/` / `frontend/` layout. The deploy pipeline now runs migrations, deploys Modal, and ships the Streamlit app to Cloud Run in the correct order with the right config.

## CI/CD (`.github/workflows/build-and-deploy.yml`)

Deploy flow is now:

1. **Alembic migrations** — `uv run alembic upgrade head` using `DATABASE_URL_DIRECT` (direct Neon connection)
2. **Modal** — `modal deploy backend/server.py` with `DATABASE_URL_POOLED` injected at deploy time via `Secret.from_dict`
3. **Cloud Run** — build/push Docker image and deploy Streamlit frontend

Also:
- `OPENAI_MODEL` is now a GitHub Actions variable (passed to Cloud Run)
- `VECTOR_STORE_CONFIG_ID` removed from Cloud Run env — config ID is hardcoded in `backend/server.py`

## Docker (`Dockerfile`, `.dockerignore`)

- Runs `streamlit run frontend/app.py`
- Copies `frontend/`, `backend/`, `db/`, and `pyproject.toml` before `pip install` (CI-generated `requirements.txt` includes `-e .`)
- `.dockerignore` updated to allow `pyproject.toml` into the build context

## API / frontend

- `vector_store_config_id` removed from `RetrieveRequest` and the frontend client
- `VECTOR_STORE_CONFIG_ID = 1` hardcoded in `backend/server.py` (alongside model paths)

## GitHub config

**New secret:** `DATABASE_URL_POOLED`  
**New variable:** `OPENAI_MODEL`  
**Removed variable:** `VECTOR_STORE_CONFIG_ID`

Keep using `DATABASE_URL_DIRECT` for migrations and `DATABASE_URL_POOLED` for Modal — don't swap them.
