### PR TITLE
Evals generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__
 .env
 notebooks
 weights
+.cursor/

--- a/evals/datasets/dataset_generation.py
+++ b/evals/datasets/dataset_generation.py
@@ -1,0 +1,23 @@
+"""Generation eval cases for the agentic RAG loop."""
+
+from pydantic_evals import Case, Dataset
+
+from evals.schemas import GenerationResult
+
+generation_dataset = Dataset[str, GenerationResult](
+    name="generation",
+    cases=[
+        Case(
+            name="case_01",
+            inputs="Who did Lincoln promote after learning he had no presidential ambitions?",
+            expected_output="Lincoln promoted Ulysses S. Grant.",
+        ),
+        Case(
+            name="case_02",
+            inputs="How did Andrew Jackson's wife die?",
+            expected_output="Rachel Jackson died of a stroke or heart attack.",
+        ),
+    ],
+)
+
+# TODO: Expand this stubbed dataset with more cases and add evaluators.

--- a/evals/datasets/dataset_generation.py
+++ b/evals/datasets/dataset_generation.py
@@ -5,6 +5,8 @@ from pydantic_evals import Case, Dataset
 from evals.evaluators import Correctness, Faithfulness, Relevance
 from evals.schemas import GenerationResult
 
+JUDGE_MODEL = "openai:gpt-5.4-mini"
+
 generation_dataset = Dataset[str, GenerationResult](
     name="generation",
     cases=[
@@ -20,9 +22,9 @@ generation_dataset = Dataset[str, GenerationResult](
         ),
     ],
     evaluators=[
-        Relevance(),
-        Correctness(),
-        Faithfulness(),
+        Relevance(model=JUDGE_MODEL),
+        Correctness(model=JUDGE_MODEL),
+        Faithfulness(model=JUDGE_MODEL),
     ],
 )
 

--- a/evals/datasets/dataset_generation.py
+++ b/evals/datasets/dataset_generation.py
@@ -2,6 +2,7 @@
 
 from pydantic_evals import Case, Dataset
 
+from evals.evaluators import Correctness, Faithfulness, Relevance
 from evals.schemas import GenerationResult
 
 generation_dataset = Dataset[str, GenerationResult](
@@ -18,6 +19,11 @@ generation_dataset = Dataset[str, GenerationResult](
             expected_output="Rachel Jackson died of a stroke or heart attack.",
         ),
     ],
+    evaluators=[
+        Relevance(),
+        Correctness(),
+        Faithfulness(),
+    ],
 )
 
-# TODO: Expand this stubbed dataset with more cases and add evaluators.
+# TODO: Expand this stubbed dataset with more cases.

--- a/evals/datasets/dataset_generation.py
+++ b/evals/datasets/dataset_generation.py
@@ -1,11 +1,13 @@
 """Generation eval cases for the agentic RAG loop."""
 
+from pydantic_ai.settings import ModelSettings
 from pydantic_evals import Case, Dataset
 
 from evals.evaluators import Correctness, Faithfulness, Relevance
 from evals.schemas import GenerationResult
 
 JUDGE_MODEL = "openai:gpt-5.4-mini"
+JUDGE_MODEL_SETTINGS = ModelSettings(temperature=0)
 
 generation_dataset = Dataset[str, GenerationResult](
     name="generation",
@@ -22,9 +24,9 @@ generation_dataset = Dataset[str, GenerationResult](
         ),
     ],
     evaluators=[
-        Relevance(model=JUDGE_MODEL),
-        Correctness(model=JUDGE_MODEL),
-        Faithfulness(model=JUDGE_MODEL),
+        Relevance(model=JUDGE_MODEL, model_settings=JUDGE_MODEL_SETTINGS),
+        Correctness(model=JUDGE_MODEL, model_settings=JUDGE_MODEL_SETTINGS),
+        Faithfulness(model=JUDGE_MODEL, model_settings=JUDGE_MODEL_SETTINGS),
     ],
 )
 

--- a/evals/datasets/dataset_retrieval.py
+++ b/evals/datasets/dataset_retrieval.py
@@ -2,10 +2,9 @@
 
 from pydantic_evals import Case, Dataset
 
-from backend.schemas import RetrievedChunk
 from evals.evaluators import HitAtK, PrecisionAtK, RecallAtK
 
-retrieval_dataset = Dataset[str, list[RetrievedChunk]](
+retrieval_dataset = Dataset[str, list[int]](
     name="retrieval",
     cases=[
         Case(

--- a/evals/evaluators.py
+++ b/evals/evaluators.py
@@ -24,28 +24,24 @@ from evals.schemas import GenerationResult
 
 
 def _hits_at_k(
-    ranked: list[RetrievedChunk],
+    ranked_chunk_ids: list[int],
     relevant_chunk_ids: list[int] | None,
     k: int,
 ) -> tuple[int, int]:
     """Return the number of relevant hits and the size of the gold set."""
     relevant = set(relevant_chunk_ids or [])
-    top_k_ids = {
-        chunk.chunk_id for chunk in ranked[:k] if chunk.chunk_id is not None
-    }
+    top_k_ids = set(ranked_chunk_ids[:k])
     return len(relevant & top_k_ids), len(relevant)
 
 
 @dataclass
-class RecallAtK(Evaluator[str, list[RetrievedChunk]]):
+class RecallAtK(Evaluator[str, list[int]]):
     k: int
 
     def get_default_evaluation_name(self) -> str:
         return f"recall@{self.k}"
 
-    def evaluate(
-        self, ctx: EvaluatorContext[str, list[RetrievedChunk]]
-    ) -> float:
+    def evaluate(self, ctx: EvaluatorContext[str, list[int]]) -> float:
         hits, num_relevant = _hits_at_k(
             ctx.output, ctx.expected_output, self.k
         )
@@ -55,29 +51,25 @@ class RecallAtK(Evaluator[str, list[RetrievedChunk]]):
 
 
 @dataclass
-class PrecisionAtK(Evaluator[str, list[RetrievedChunk]]):
+class PrecisionAtK(Evaluator[str, list[int]]):
     k: int
 
     def get_default_evaluation_name(self) -> str:
         return f"precision@{self.k}"
 
-    def evaluate(
-        self, ctx: EvaluatorContext[str, list[RetrievedChunk]]
-    ) -> float:
+    def evaluate(self, ctx: EvaluatorContext[str, list[int]]) -> float:
         hits, _ = _hits_at_k(ctx.output, ctx.expected_output, self.k)
         return hits / self.k
 
 
 @dataclass
-class HitAtK(Evaluator[str, list[RetrievedChunk]]):
+class HitAtK(Evaluator[str, list[int]]):
     k: int
 
     def get_default_evaluation_name(self) -> str:
         return f"hit@{self.k}"
 
-    def evaluate(
-        self, ctx: EvaluatorContext[str, list[RetrievedChunk]]
-    ) -> bool:
+    def evaluate(self, ctx: EvaluatorContext[str, list[int]]) -> bool:
         hits, num_relevant = _hits_at_k(
             ctx.output, ctx.expected_output, self.k
         )

--- a/evals/evaluators.py
+++ b/evals/evaluators.py
@@ -82,21 +82,15 @@ class HitAtK(Evaluator[str, list[RetrievedChunk]]):
         return hits > 0
 
 
-def _format_retrieved_chunks(chunks: list[RetrievedChunk]) -> str:
-    if not chunks:
-        return "(no documents retrieved)"
-    parts: list[str] = []
-    for index, chunk in enumerate(chunks, start=1):
-        header = f"[{index}] {chunk.source} (chunk_id={chunk.chunk_id})"
-        parts.append(f"{header}\n{chunk.text}")
-    return "\n\n".join(parts)
-
-
 def _faithfulness_inputs(question: str, chunks: list[RetrievedChunk]) -> str:
-    return (
-        f"Question: {question}\n\n"
-        f"Retrieved documents:\n{_format_retrieved_chunks(chunks)}"
-    )
+    if not chunks:
+        documents = "No documents retrieved"
+    else:
+        documents = "\n\n".join(
+            f"### Document {index}:\n{chunk.text}"
+            for index, chunk in enumerate(chunks, start=1)
+        )
+    return f"## Question\n{question}\n\n## Retrieved documents\n{documents}"
 
 
 def _grading_to_reason(grading: GradingOutput) -> EvaluationReason:

--- a/evals/evaluators.py
+++ b/evals/evaluators.py
@@ -1,10 +1,22 @@
 """Evaluators for retrieval and generation experiments."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
-from pydantic_evals.evaluators import Evaluator, EvaluatorContext
+from pydantic_ai import models
+from pydantic_ai.settings import ModelSettings
+from pydantic_evals.evaluators import (
+    EvaluationReason,
+    Evaluator,
+    EvaluatorContext,
+)
+from pydantic_evals.evaluators.llm_as_a_judge import (
+    GradingOutput,
+    judge_input_output,
+    judge_input_output_expected,
+)
 
 from backend.schemas import RetrievedChunk
+from evals.schemas import GenerationResult
 
 
 def _hits_at_k(
@@ -68,3 +80,101 @@ class HitAtK(Evaluator[str, list[RetrievedChunk]]):
         if num_relevant == 0:
             return False
         return hits > 0
+
+
+def _format_retrieved_chunks(chunks: list[RetrievedChunk]) -> str:
+    if not chunks:
+        return "(no documents retrieved)"
+    parts: list[str] = []
+    for index, chunk in enumerate(chunks, start=1):
+        header = f"[{index}] {chunk.source} (chunk_id={chunk.chunk_id})"
+        parts.append(f"{header}\n{chunk.text}")
+    return "\n\n".join(parts)
+
+
+def _faithfulness_inputs(question: str, chunks: list[RetrievedChunk]) -> str:
+    return (
+        f"Question: {question}\n\n"
+        f"Retrieved documents:\n{_format_retrieved_chunks(chunks)}"
+    )
+
+
+def _grading_to_reason(grading: GradingOutput) -> EvaluationReason:
+    return EvaluationReason(value=grading.pass_, reason=grading.reason)
+
+
+DEFAULT_RELEVANCE_RUBRIC = (
+    "The response directly addresses the question that was asked."
+)
+DEFAULT_CORRECTNESS_RUBRIC = (
+    "The response is factually correct and consistent with the expected key "
+    "facts. Minor wording differences are acceptable."
+)
+DEFAULT_FAITHFULNESS_RUBRIC = (
+    "Every factual claim in the response is supported by the retrieved "
+    "documents. Claims that rely on general knowledge outside the retrieved "
+    "documents should fail."
+)
+
+
+@dataclass
+class Relevance(Evaluator[str, GenerationResult]):
+    rubric: str = DEFAULT_RELEVANCE_RUBRIC
+    model: models.Model | models.KnownModelName | str | None = None
+    model_settings: ModelSettings | None = None
+
+    async def evaluate(
+        self, ctx: EvaluatorContext[str, GenerationResult]
+    ) -> EvaluationReason:
+        grading = await judge_input_output(
+            ctx.inputs,
+            ctx.output.answer,
+            self.rubric,
+            self.model,
+            self.model_settings,
+        )
+        return _grading_to_reason(grading)
+
+
+@dataclass
+class Correctness(Evaluator[str, GenerationResult]):
+    rubric: str = DEFAULT_CORRECTNESS_RUBRIC
+    model: models.Model | models.KnownModelName | str | None = None
+    model_settings: ModelSettings | None = None
+
+    async def evaluate(
+        self, ctx: EvaluatorContext[str, GenerationResult]
+    ) -> EvaluationReason:
+        if ctx.expected_output is None:
+            return EvaluationReason(
+                value=False,
+                reason="No expected output provided for this case.",
+            )
+        grading = await judge_input_output_expected(
+            ctx.inputs,
+            ctx.output.answer,
+            ctx.expected_output,
+            self.rubric,
+            self.model,
+            self.model_settings,
+        )
+        return _grading_to_reason(grading)
+
+
+@dataclass
+class Faithfulness(Evaluator[str, GenerationResult]):
+    rubric: str = DEFAULT_FAITHFULNESS_RUBRIC
+    model: models.Model | models.KnownModelName | str | None = None
+    model_settings: ModelSettings | None = field(default=None)
+
+    async def evaluate(
+        self, ctx: EvaluatorContext[str, GenerationResult]
+    ) -> EvaluationReason:
+        grading = await judge_input_output(
+            _faithfulness_inputs(ctx.inputs, ctx.output.retrieved_chunks),
+            ctx.output.answer,
+            self.rubric,
+            self.model,
+            self.model_settings,
+        )
+        return _grading_to_reason(grading)

--- a/evals/evaluators.py
+++ b/evals/evaluators.py
@@ -18,6 +18,10 @@ from pydantic_evals.evaluators.llm_as_a_judge import (
 from backend.schemas import RetrievedChunk
 from evals.schemas import GenerationResult
 
+# ===========================================================================
+# Retrieval
+# ===========================================================================
+
 
 def _hits_at_k(
     ranked: list[RetrievedChunk],
@@ -80,6 +84,11 @@ class HitAtK(Evaluator[str, list[RetrievedChunk]]):
         if num_relevant == 0:
             return False
         return hits > 0
+
+
+# ===========================================================================
+# Generation
+# ===========================================================================
 
 
 def _faithfulness_inputs(question: str, chunks: list[RetrievedChunk]) -> str:

--- a/evals/evaluators.py
+++ b/evals/evaluators.py
@@ -96,8 +96,7 @@ def _faithfulness_inputs(question: str, chunks: list[RetrievedChunk]) -> str:
         documents = "No documents retrieved"
     else:
         documents = "\n\n".join(
-            f"### Document {index}:\n{chunk.text}"
-            for index, chunk in enumerate(chunks, start=1)
+            f"### Document {chunk.chunk_id}\n{chunk.text}" for chunk in chunks
         )
     return f"## Question\n{question}\n\n## Retrieved documents\n{documents}"
 

--- a/evals/run_eval_generation.py
+++ b/evals/run_eval_generation.py
@@ -1,0 +1,52 @@
+"""Run generation evals against the generation dataset."""
+
+import argparse
+import sys
+
+import logfire
+from dotenv import load_dotenv
+
+from evals.datasets.dataset_generation import generation_dataset
+from evals.tasks import make_generation_task
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run generation evals.")
+    parser.add_argument(
+        "--top-k-retrieval",
+        "-k1",
+        type=int,
+        dest="top_k_retrieval",
+        help="Number of chunks to retrieve from the vector database.",
+    )
+    parser.add_argument(
+        "--top-k-rerank",
+        "-k2",
+        type=int,
+        dest="top_k_rerank",
+        help="Number of chunks to keep after reranking.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    load_dotenv()
+    logfire.configure(
+        service_name="presidents-rag-evals",
+        environment="dev",
+    )
+
+    args = parse_args()
+    task = make_generation_task(args.top_k_retrieval, args.top_k_rerank)
+    report = generation_dataset.evaluate_sync(
+        task,
+        metadata={
+            "top_k_retrieval": args.top_k_retrieval,
+            "top_k_rerank": args.top_k_rerank,
+        },
+    )
+    report.print()
+
+
+if __name__ == "__main__":
+    sys.exit(main() or 0)

--- a/evals/schemas.py
+++ b/evals/schemas.py
@@ -1,0 +1,13 @@
+"""Shared types for Pydantic Evals experiments."""
+
+from pydantic import BaseModel
+
+from backend.schemas import RetrievedChunk
+
+
+class GenerationResult(BaseModel):
+    """Output of a single agentic RAG eval run."""
+
+    answer: str
+    retrieved_chunks: list[RetrievedChunk]
+    cited_chunks: list[RetrievedChunk]

--- a/evals/tasks.py
+++ b/evals/tasks.py
@@ -2,7 +2,11 @@
 
 from collections.abc import Callable
 
+from pydantic_ai.usage import UsageLimits
+
 from backend.schemas import RetrievedChunk
+from evals.schemas import GenerationResult
+from frontend.agent import REQUEST_LIMIT, AgentDeps, agent, parse_agent_run
 from frontend.client import RAGClient
 
 
@@ -16,5 +20,33 @@ def make_retrieval_task(
     def task(query: str) -> list[RetrievedChunk]:
         chunks = rag_client.retrieve(query, top_k=top_k_retrieval)
         return rag_client.rerank(query, chunks, top_k_rerank)
+
+    return task
+
+
+def make_generation_task(
+    top_k_retrieval: int,
+    top_k_rerank: int,
+) -> Callable[[str], GenerationResult]:
+    """Return a task that runs the agentic RAG loop for a single query."""
+    rag_client = RAGClient()
+
+    def task(query: str) -> GenerationResult:
+        deps = AgentDeps(
+            client=rag_client,
+            top_k_retrieval=top_k_retrieval,
+            top_k_rerank=top_k_rerank,
+        )
+        result = agent.run_sync(
+            query,
+            deps=deps,
+            usage_limits=UsageLimits(request_limit=REQUEST_LIMIT),
+        )
+        answer, cited_chunks = parse_agent_run(result, deps)
+        return GenerationResult(
+            answer=answer,
+            retrieved_chunks=list(deps.seen.values()),
+            cited_chunks=cited_chunks,
+        )
 
     return task

--- a/evals/tasks.py
+++ b/evals/tasks.py
@@ -4,7 +4,6 @@ from collections.abc import Callable
 
 from pydantic_ai.usage import UsageLimits
 
-from backend.schemas import RetrievedChunk
 from evals.schemas import GenerationResult
 from frontend.agent import REQUEST_LIMIT, AgentDeps, agent, parse_agent_run
 from frontend.client import RAGClient
@@ -13,18 +12,18 @@ from frontend.client import RAGClient
 def make_retrieval_task(
     top_k_retrieval: int,
     top_k_rerank: int,
-) -> Callable[[str], list[RetrievedChunk]]:
+) -> Callable[[str], list[int]]:
     """Return a task that runs retrieve → rerank for a single query."""
     rag_client = RAGClient()
 
-    def task(query: str) -> list[RetrievedChunk]:
+    def task(query: str) -> list[int]:
         chunks = rag_client.retrieve(query, top_k=top_k_retrieval)
-        return rag_client.rerank(query, chunks, top_k_rerank)
+        ranked = rag_client.rerank(query, chunks, top_k_rerank)
+        return [
+            chunk.chunk_id for chunk in ranked if chunk.chunk_id is not None
+        ]
 
     return task
-
-
-# TODO: Update signature. Should return list[int]
 
 
 def make_generation_task(

--- a/evals/tasks.py
+++ b/evals/tasks.py
@@ -24,6 +24,9 @@ def make_retrieval_task(
     return task
 
 
+# TODO: Update signature. Should return list[int]
+
+
 def make_generation_task(
     top_k_retrieval: int,
     top_k_rerank: int,


### PR DESCRIPTION
## Summary

Adds a **generation eval pipeline** for the agentic RAG agent, complementing the existing retrieval evals. Generation evals run the full `agent.run_sync` loop (not single-shot `ask`) and score answers with LLM judges on three metrics: **Relevance**, **Correctness**, and **Faithfulness**.

Also includes a small cleanup to retrieval evals: the retrieval task now returns `list[int]` (ranked chunk IDs) instead of `list[RetrievedChunk]`, aligning task output with `expected_output` and simplifying the hit/recall/precision evaluators.

### Generation evals

- **`GenerationResult`** — structured task output with `answer`, all retrieved chunks (`deps.seen`), and cited chunks
- **`make_generation_task`** — stateless agent invocation per eval case
- **`generation_dataset`** — stub dataset with placeholder cases and key-facts expected outputs (to be expanded)
- **LLM judge evaluators** — thin wrappers around pydantic_evals' `judge_input_output` / `judge_input_output_expected`:
  - *Relevance* — does the answer address the question?
  - *Correctness* — is the answer consistent with expected key facts?
  - *Faithfulness* — is the answer grounded in retrieved documents?
- **`run_eval_generation.py`** — runner mirroring the retrieval CLI (`-k1`, `-k2`) and Logfire config

Judge config lives in `dataset_generation.py`: `gpt-5.4-mini` at `temperature=0`.

### Retrieval eval tweak

- `make_retrieval_task` extracts chunk IDs after rerank
- Retrieval evaluators and dataset typed as `list[int]` throughout

## Test plan

- [x] Run retrieval evals: `uv run python -m evals.run_eval_retrieval -k1 50 -k2 10`
- [x] Run generation evals (requires backend + OpenAI): `uv run python -m evals.run_eval_generation -k1 50 -k2 10`
- [x] Confirm both scripts log to the `presidents-rag-evals` Logfire project
- [x] Verify generation report shows Relevance / Correctness / Faithfulness assertions
- [ ] Expand `generation_dataset` cases beyond the two placeholders (follow-up)