### PR TITLE
Update vector store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ notebooks
 weights
 .cursor/
 text/
+.neon

--- a/alembic/versions/20260628_140303_add_document_to_chunk_schema.py
+++ b/alembic/versions/20260628_140303_add_document_to_chunk_schema.py
@@ -1,0 +1,61 @@
+"""add document to chunk schema
+
+Revision ID: 720ed6dc040e
+Revises: 73e3b4337b7b
+Create Date: 2026-06-28 14:03:03.246784
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "720ed6dc040e"
+down_revision: Union[str, Sequence[str], None] = "73e3b4337b7b"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# Existing rows stored the filename in ``source``; all current data is Wikipedia.
+_LEGACY_SOURCE = "wikipedia"
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        "chunks_dim_384",
+        sa.Column("document", sa.Text(), nullable=True),
+    )
+    op.execute("UPDATE chunks_dim_384 SET document = source")
+
+    op.drop_constraint(
+        "uq_chunks_dim_384_vector_store_config_source_start",
+        "chunks_dim_384",
+        type_="unique",
+    )
+    op.execute(f"UPDATE chunks_dim_384 SET source = '{_LEGACY_SOURCE}'")
+
+    op.alter_column("chunks_dim_384", "document", nullable=False)
+    op.create_unique_constraint(
+        "uq_chunks_dim_384_vector_store_config_source_document_start",
+        "chunks_dim_384",
+        ["vector_store_config_id", "source", "document", "start_index"],
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_constraint(
+        "uq_chunks_dim_384_vector_store_config_source_document_start",
+        "chunks_dim_384",
+        type_="unique",
+    )
+    op.execute("UPDATE chunks_dim_384 SET source = document")
+    op.drop_column("chunks_dim_384", "document")
+    op.create_unique_constraint(
+        "uq_chunks_dim_384_vector_store_config_source_start",
+        "chunks_dim_384",
+        ["vector_store_config_id", "source", "start_index"],
+    )

--- a/backend/retrieval.py
+++ b/backend/retrieval.py
@@ -46,6 +46,7 @@ def retrieve(
     return [
         RetrievedChunk(
             source=chunk.source,
+            document=chunk.document,
             start_index=chunk.start_index,
             text=chunk.text,
             retrieval_score=1.0 - float(distance),

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -6,11 +6,13 @@ from pydantic import BaseModel
 class RetrievedChunk(BaseModel):
     """A single document chunk returned by retrieval/reranking.
 
-    Identity is the ``(source, start_index)`` pair. ``chunk_id`` is the DB
-    primary key, carried along for eval joins/debugging but not relied upon.
+    Identity is the ``(source, document, start_index)`` triple. ``chunk_id`` is
+    the DB primary key, carried along for eval joins/debugging but not relied
+    upon.
     """
 
     source: str
+    document: str
     start_index: int
     text: str
     retrieval_score: float | None = None

--- a/db/models.py
+++ b/db/models.py
@@ -52,8 +52,9 @@ class ChunkDim384(Base):
         UniqueConstraint(
             "vector_store_config_id",
             "source",
+            "document",
             "start_index",
-            name="uq_chunks_dim_384_vector_store_config_source_start",
+            name="uq_chunks_dim_384_vector_store_config_source_document_start",
         ),
     )
 
@@ -65,6 +66,7 @@ class ChunkDim384(Base):
         index=True,
     )
     source: Mapped[str] = mapped_column(Text, nullable=False)
+    document: Mapped[str] = mapped_column(Text, nullable=False)
     start_index: Mapped[int] = mapped_column(Integer, nullable=False)
     text: Mapped[str] = mapped_column(Text, nullable=False)
     embedding: Mapped[list[float]] = mapped_column(

--- a/scripts/ingest.py
+++ b/scripts/ingest.py
@@ -21,6 +21,14 @@ class EmbeddingModelConfig:
     dim: int
 
 
+@dataclass(frozen=True)
+class ChunkRecord:
+    source: str
+    document: str
+    start_index: int
+    text: str
+
+
 MODELS = {
     "sentence-transformers/all-MiniLM-L6-v2": EmbeddingModelConfig(
         weights_path="weights/sentence-transformers_all-MiniLM-L6-v2",
@@ -28,20 +36,11 @@ MODELS = {
         dim=384,
     ),
 }
-
 PROJECT_ROOT = Path(__file__).parent.parent
 SOURCES: dict[str, Path] = {
     "wikipedia": PROJECT_ROOT / "text" / "wikipedia",
     "miller_center": PROJECT_ROOT / "text" / "miller_center",
 }
-
-
-@dataclass(frozen=True)
-class ChunkRecord:
-    source: str
-    document: str
-    start_index: int
-    text: str
 
 
 def chunk_txt_files(
@@ -78,11 +77,6 @@ def ingest(
     batch_size: int,
 ) -> int:
     """Embed ``chunks`` and load them into the vector store."""
-    if model_name not in MODELS:
-        raise ValueError(
-            f"Model {model_name!r} is not allowed. "
-            f"Choose from: {list(MODELS)}"
-        )
     if not chunks:
         raise ValueError("No chunks to ingest.")
 
@@ -164,8 +158,20 @@ def main() -> None:
         required=True,
         help="Number of overlapping characters between chunks.",
     )
-    parser.add_argument("-b", "--batch-size", type=int, default=64)
+    parser.add_argument(
+        "-b",
+        "--batch-size",
+        type=int,
+        default=64,
+        help="Batch size for embedding chunks.",
+    )
     args = parser.parse_args()
+
+    if args.model not in MODELS:
+        raise ValueError(
+            f"Model {args.model!r} is not allowed. "
+            f"Choose from: {list(MODELS)}"
+        )
 
     start_time = time.time()
     chunks: list[ChunkRecord] = []

--- a/scripts/ingest.py
+++ b/scripts/ingest.py
@@ -29,6 +29,12 @@ MODELS = {
     ),
 }
 
+PROJECT_ROOT = Path(__file__).parent.parent
+SOURCES: dict[str, Path] = {
+    "wikipedia": PROJECT_ROOT / "text" / "wikipedia",
+    "miller_center": PROJECT_ROOT / "text" / "miller_center",
+}
+
 
 @dataclass(frozen=True)
 class ChunkRecord:
@@ -40,7 +46,7 @@ class ChunkRecord:
 
 def chunk_txt_files(
     source: str,
-    documents_folder: str,
+    documents_folder: Path,
     chunk_size: int,
     chunk_overlap: int,
 ) -> list[ChunkRecord]:
@@ -50,7 +56,7 @@ def chunk_txt_files(
         add_start_index=True,
     )
     chunks: list[ChunkRecord] = []
-    for path in sorted(Path(documents_folder).glob("*.txt")):
+    for path in sorted(documents_folder.glob("*.txt")):
         text = path.read_text(encoding="utf-8")
         for document in text_splitter.create_documents([text]):
             chunks.append(
@@ -65,29 +71,24 @@ def chunk_txt_files(
 
 
 def ingest(
-    source: str,
-    documents_folder: str,
+    chunks: list[ChunkRecord],
     model_name: str,
     chunk_size: int,
     chunk_overlap: int,
     batch_size: int,
 ) -> int:
-    """Ingest text files into the vector store."""
+    """Embed ``chunks`` and load them into the vector store."""
     if model_name not in MODELS:
         raise ValueError(
             f"Model {model_name!r} is not allowed. "
             f"Choose from: {list(MODELS)}"
         )
-    model = MODELS[model_name]
-    chunks = chunk_txt_files(
-        source, documents_folder, chunk_size, chunk_overlap
-    )
     if not chunks:
-        raise ValueError(f"No .txt files found in {documents_folder!r}")
+        raise ValueError("No chunks to ingest.")
 
+    model = MODELS[model_name]
     session = get_session()
     try:
-        # 1. Create vector store config record
         existing = session.execute(
             select(VectorStoreConfig).where(
                 VectorStoreConfig.model_name == model_name,
@@ -109,7 +110,6 @@ def ingest(
         session.add(vector_store_config)
         session.flush()
 
-        # 2. Create embedding records
         embedder = SentenceTransformer(model.weights_path)
         texts = [chunk.text for chunk in chunks]
         embeddings = embedder.encode(
@@ -141,19 +141,7 @@ def ingest(
 def main() -> None:
     load_dotenv()
     parser = argparse.ArgumentParser(
-        description="Ingest text files into the vector store."
-    )
-    parser.add_argument(
-        "-s",
-        "--source",
-        required=True,
-        help="Data source collection id (e.g. wikipedia, miller_center).",
-    )
-    parser.add_argument(
-        "-d",
-        "--documents-folder",
-        required=True,
-        help="Folder containing .txt files to ingest.",
+        description="Ingest all configured text sources into the vector store."
     )
     parser.add_argument(
         "-m",
@@ -180,19 +168,31 @@ def main() -> None:
     args = parser.parse_args()
 
     start_time = time.time()
+    chunks: list[ChunkRecord] = []
+    for source, documents_folder in SOURCES.items():
+        source_chunks = chunk_txt_files(
+            source,
+            documents_folder,
+            args.chunk_size,
+            args.chunk_overlap,
+        )
+        if not source_chunks:
+            raise ValueError(f"No .txt files found in {documents_folder!r}")
+        chunks.extend(source_chunks)
+        print(
+            f"Chunked {len(source_chunks)} chunks from {source!r} "
+            f"({documents_folder})"
+        )
+
     num_chunks = ingest(
-        source=args.source,
-        documents_folder=args.documents_folder,
+        chunks=chunks,
         model_name=args.model,
         chunk_size=args.chunk_size,
         chunk_overlap=args.chunk_overlap,
         batch_size=args.batch_size,
     )
     elapsed = time.time() - start_time
-    print(
-        f"Ingested {num_chunks} chunks from {args.source!r} "
-        f"({args.documents_folder}) in {elapsed:.1f}s"
-    )
+    print(f"Ingested {num_chunks} total chunks in {elapsed:.1f}s")
 
 
 if __name__ == "__main__":

--- a/scripts/ingest.py
+++ b/scripts/ingest.py
@@ -33,11 +33,13 @@ MODELS = {
 @dataclass(frozen=True)
 class ChunkRecord:
     source: str
+    document: str
     start_index: int
     text: str
 
 
 def chunk_txt_files(
+    source: str,
     documents_folder: str,
     chunk_size: int,
     chunk_overlap: int,
@@ -53,7 +55,8 @@ def chunk_txt_files(
         for document in text_splitter.create_documents([text]):
             chunks.append(
                 ChunkRecord(
-                    source=path.name,
+                    source=source,
+                    document=path.name,
                     start_index=document.metadata["start_index"],
                     text=document.page_content,
                 )
@@ -62,6 +65,7 @@ def chunk_txt_files(
 
 
 def ingest(
+    source: str,
     documents_folder: str,
     model_name: str,
     chunk_size: int,
@@ -75,7 +79,9 @@ def ingest(
             f"Choose from: {list(MODELS)}"
         )
     model = MODELS[model_name]
-    chunks = chunk_txt_files(documents_folder, chunk_size, chunk_overlap)
+    chunks = chunk_txt_files(
+        source, documents_folder, chunk_size, chunk_overlap
+    )
     if not chunks:
         raise ValueError(f"No .txt files found in {documents_folder!r}")
 
@@ -115,6 +121,7 @@ def ingest(
             model.data_model(
                 vector_store_config_id=vector_store_config.id,
                 source=chunk.source,
+                document=chunk.document,
                 start_index=chunk.start_index,
                 text=chunk.text,
                 embedding=embedding.tolist(),
@@ -135,6 +142,12 @@ def main() -> None:
     load_dotenv()
     parser = argparse.ArgumentParser(
         description="Ingest text files into the vector store."
+    )
+    parser.add_argument(
+        "-s",
+        "--source",
+        required=True,
+        help="Data source collection id (e.g. wikipedia, miller_center).",
     )
     parser.add_argument(
         "-d",
@@ -168,6 +181,7 @@ def main() -> None:
 
     start_time = time.time()
     num_chunks = ingest(
+        source=args.source,
         documents_folder=args.documents_folder,
         model_name=args.model,
         chunk_size=args.chunk_size,
@@ -176,7 +190,8 @@ def main() -> None:
     )
     elapsed = time.time() - start_time
     print(
-        f"Ingested {num_chunks} chunks from {args.documents_folder} in {elapsed:.1f}s"
+        f"Ingested {num_chunks} chunks from {args.source!r} "
+        f"({args.documents_folder}) in {elapsed:.1f}s"
     )
 
 


### PR DESCRIPTION
## Summary

Prepares the vector store for multiple data sources by separating **collection** from **document**.

Previously, `ChunkDim384.source` stored the filename each chunk came from. This PR repurpose `source` for the data collection (`wikipedia`, `miller_center`) and adds a `document` field for the filename. Chunk identity is now `(source, document, start_index)`.

**Database & API**
- Adds `document` to `ChunkDim384` and updates the unique constraint
- Alembic migration backfills existing rows: filenames move to `document`, `source` is set to `wikipedia`
- Exposes `document` on `RetrievedChunk`; retrieval populates both fields
- `RetrieveRequest.source` is unchanged — it still filters by collection

**Ingest**
- Ingests both fixed sources (`wikipedia` → `text/wikipedia`, `miller_center` → `text/miller_center`) in one run
- Refactored so `main()` chunks all sources into `ChunkRecord`s, then `ingest()` embeds and persists in a single pass
- Removed `--documents-folder` CLI arg

**Out of scope:** no frontend changes yet (follow-up needed for source display/citations).
