### PR TITLE
Wire sources in frontend

### DIFF
--- a/backend/retrieval.py
+++ b/backend/retrieval.py
@@ -22,14 +22,18 @@ def retrieve(
     vector_store_config_id: int,
     query: str,
     top_k: int,
-    source: str | None = None,
+    sources: list[str] | None = None,
 ) -> list[RetrievedChunk]:
     """Embed ``query`` and return the ``top_k`` nearest chunks by cosine distance.
 
     ``retrieval_score`` is reported as cosine similarity (``1 - distance``), so
-    higher means more similar.
+    higher means more similar. When ``sources`` is set, only chunks from those
+    collections are considered; ``None`` searches the full knowledge base.
     """
     import torch
+
+    if sources is not None and not sources:
+        return []
 
     with torch.no_grad():
         q_emb = embedder.encode([query])[0].tolist()
@@ -38,8 +42,8 @@ def retrieve(
         ChunkDim384,
         ChunkDim384.embedding.cosine_distance(q_emb).label("distance"),
     ).where(ChunkDim384.vector_store_config_id == vector_store_config_id)
-    if source is not None:
-        stmt = stmt.where(ChunkDim384.source == source)
+    if sources is not None:
+        stmt = stmt.where(ChunkDim384.source.in_(sources))
     stmt = stmt.order_by("distance").limit(top_k)
 
     rows = session.execute(stmt).all()

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -23,7 +23,7 @@ class RetrievedChunk(BaseModel):
 class RetrieveRequest(BaseModel):
     query: str
     top_k: int
-    source: str | None = None
+    sources: list[str] | None = None
 
 
 class RerankRequest(BaseModel):

--- a/backend/server.py
+++ b/backend/server.py
@@ -16,7 +16,7 @@ SENTENCE_TRANSFORMER_PATH = (
     "/data/weights/sentence-transformers_all-MiniLM-L6-v2"
 )
 CROSS_ENCODER_PATH = "/data/weights/cross-encoder_ms-marco-MiniLM-L-6-v2"
-VECTOR_STORE_CONFIG_ID = 1
+VECTOR_STORE_CONFIG_ID = 3
 
 # The runtime queries Postgres through the pooled connection. The value is read
 # from the deploy environment (GitHub secrets in CI, .env locally) and injected

--- a/backend/server.py
+++ b/backend/server.py
@@ -86,7 +86,7 @@ class Server:
                     vector_store_config_id=VECTOR_STORE_CONFIG_ID,
                     query=request.query,
                     top_k=request.top_k,
-                    source=request.source,
+                    sources=request.sources,
                 )
             finally:
                 session.close()

--- a/frontend/agent.py
+++ b/frontend/agent.py
@@ -36,8 +36,8 @@ TOP_K_RERANK = 10
 SYSTEM_PROMPT = """
 You are a research assistant answering questions about US Presidents and
 Secretaries of State. You have one tool, `search_knowledge_base`, which takes a
-search query and returns relevant document chunks from a Wikipedia knowledge
-base. Each chunk has a `chunk_id`.
+search query and returns relevant document chunks from a knowledge
+base. Each chunk has a `chunk_id` and a `source` collection label.
 
 How to work:
 - Decide how much effort the question needs. A simple, single-fact question may
@@ -94,11 +94,13 @@ class AgentResponse(BaseModel):
 class AgentDeps:
     """Per-run dependencies and state.
 
-    ``seen`` accumulates every chunk returned by the tool across the whole run,
-    keyed by ``chunk_id`` so repeats dedupe naturally.
+    ``sources`` is the per-turn retrieval policy (set before each run).
+    ``seen`` accumulates every chunk returned by the tool across the whole
+    conversation, keyed by ``chunk_id`` so repeats dedupe naturally.
     """
 
     client: RAGClient
+    sources: list[str] | None = None
     top_k_retrieval: int = TOP_K_RETRIEVAL
     top_k_rerank: int = TOP_K_RERANK
     seen: dict[int, RetrievedChunk] = field(default_factory=dict)
@@ -125,7 +127,11 @@ def search_knowledge_base(
         query: A focused natural-language search query.
     """
     deps = ctx.deps
-    chunks = deps.client.retrieve(query, top_k=deps.top_k_retrieval)
+    chunks = deps.client.retrieve(
+        query,
+        top_k=deps.top_k_retrieval,
+        sources=deps.sources,
+    )
     top = deps.client.rerank(query, chunks, deps.top_k_rerank)
     for chunk in top:
         if chunk.chunk_id is not None:

--- a/frontend/client.py
+++ b/frontend/client.py
@@ -51,14 +51,14 @@ class RAGClient:
         self,
         query: str,
         top_k: int,
-        source: str | None = None,
+        sources: list[str] | None = None,
     ) -> list[RetrievedChunk]:
         response = self.http_client.post(
             "/retrieve",
             json={
                 "query": query,
                 "top_k": top_k,
-                "source": source,
+                "sources": sources,
             },
         )
         response.raise_for_status()
@@ -96,14 +96,14 @@ class RAGClient:
     def ask(
         self,
         query: str,
-        source: str | None = None,
+        sources: list[str] | None = None,
         top_k_retrieval: int = 100,
         top_k_rerank: int = 20,
     ) -> tuple[str, list[RetrievedChunk]]:
         chunks = self.retrieve(
             query=query,
             top_k=top_k_retrieval,
-            source=source,
+            sources=sources,
         )
         top_chunks = self.rerank(query, chunks, top_k_rerank)
         prompt = self.prompt_template.render(

--- a/frontend/dash_app/assets/app.css
+++ b/frontend/dash_app/assets/app.css
@@ -69,7 +69,7 @@ body { background: #f4efe4; }
 .example-card { transition: border-color .12s ease; }
 .example-card:hover { border-color: #c8a8a2; }
 
-.menu-row:hover { background: #f5eeddb0 !important; }
+.menu-row:hover { background: #f0e7d6; }
 
 /* Muted by default (composer empty = not valid to submit); the .active class
    is toggled on by a clientside callback as soon as there's input. */

--- a/frontend/dash_app/callbacks.py
+++ b/frontend/dash_app/callbacks.py
@@ -23,21 +23,26 @@ from dash import (
     callback,
     clientside_callback,
     ctx,
+    html,
 )
 from dash.exceptions import PreventUpdate
 
-from frontend.dash_app.components.composer import model_menu
+from frontend.dash_app import theme as t
+from frontend.dash_app.components.composer import model_menu, sources_menu
 from frontend.dash_app.components.conversation import render_conversation
 from frontend.dash_app.components.welcome import welcome
 from frontend.dash_app.config import (
     DEFAULT_MODEL_ID,
+    DEFAULT_SOURCE_IDS,
     EXAMPLE_PROMPTS,
     ID,
     POP_ABOUT,
     POP_MODEL,
     POP_NEWCONFIRM,
     POP_SOURCES,
+    SOURCES,
     model_name,
+    sources_chip_label,
 )
 from frontend.dash_app.services.conversation import store
 
@@ -54,10 +59,13 @@ from frontend.dash_app.services.conversation import store
     State(ID.INPUT, "value"),
     State(ID.CONVERSATION, "data"),
     State(ID.MODEL, "data"),
+    State(ID.SOURCES, "data"),
     State(ID.PENDING, "data"),
     prevent_initial_call=True,
 )
-def submit(send_clicks, _example_clicks, text, conv_id, model_id, pending):
+def submit(
+    send_clicks, _example_clicks, text, conv_id, model_id, source_ids, pending
+):
     if pending:  # a run is already in flight; ignore further submits
         raise PreventUpdate
 
@@ -79,11 +87,17 @@ def submit(send_clicks, _example_clicks, text, conv_id, model_id, pending):
 
     conv_id = conv_id or uuid.uuid4().hex
     model_id = model_id or DEFAULT_MODEL_ID
+    source_ids = source_ids or DEFAULT_SOURCE_IDS
     store.add_user_message(conv_id, query)
 
     conv = store.get(conv_id)
     children = render_conversation(conv, loading=True)
-    pending = {"conv_id": conv_id, "query": query, "model": model_id}
+    pending = {
+        "conv_id": conv_id,
+        "query": query,
+        "model": model_id,
+        "sources": source_ids,
+    }
     return children, "", pending, conv_id, None
 
 
@@ -96,7 +110,12 @@ def submit(send_clicks, _example_clicks, text, conv_id, model_id, pending):
 def run_agent(pending):
     if not pending:
         raise PreventUpdate
-    store.run_assistant(pending["conv_id"], pending["query"], pending["model"])
+    store.run_assistant(
+        pending["conv_id"],
+        pending["query"],
+        pending["model"],
+        pending["sources"],
+    )
     conv = store.get(pending["conv_id"])
     return render_conversation(conv, loading=False), None
 
@@ -134,6 +153,43 @@ def select_model(_clicks):
         raise PreventUpdate
     model_id = trigger["index"]
     return model_id, model_name(model_id), model_menu(model_id), None
+
+
+# --- Source selection ----------------------------------------------------------
+@callback(
+    Output(ID.SOURCES, "data"),
+    Output(ID.SOURCES_CHIP_LABEL, "children"),
+    Output(ID.SOURCES_MENU, "children"),
+    Output(f"{ID.SOURCES_MENU}-count", "children"),
+    Output(ID.POPOVER, "data", allow_duplicate=True),
+    Input({"type": "source-option", "index": ALL}, "n_clicks"),
+    State(ID.SOURCES, "data"),
+    prevent_initial_call=True,
+)
+def select_sources(_clicks, current):
+    trigger = ctx.triggered_id
+    if not isinstance(trigger, dict) or not ctx.triggered[0]["value"]:
+        raise PreventUpdate
+
+    source_id = trigger["index"]
+    selected = list(current or DEFAULT_SOURCE_IDS)
+    if source_id in selected:
+        if len(selected) > 1:
+            selected.remove(source_id)
+    else:
+        selected.append(source_id)
+
+    count = html.Span(
+        f"{len(selected)} of {len(SOURCES)} selected",
+        style={"fontFamily": t.SANS, "fontSize": "12px", "color": t.MUTED},
+    )
+    return (
+        selected,
+        sources_chip_label(selected),
+        sources_menu(selected),
+        count,
+        None,
+    )
 
 
 # --- Popover open/close (which popover is open) -------------------------------

--- a/frontend/dash_app/callbacks.py
+++ b/frontend/dash_app/callbacks.py
@@ -161,7 +161,6 @@ def select_model(_clicks):
     Output(ID.SOURCES_CHIP_LABEL, "children"),
     Output(ID.SOURCES_MENU, "children"),
     Output(f"{ID.SOURCES_MENU}-count", "children"),
-    Output(ID.POPOVER, "data", allow_duplicate=True),
     Input({"type": "source-option", "index": ALL}, "n_clicks"),
     State(ID.SOURCES, "data"),
     prevent_initial_call=True,
@@ -188,7 +187,6 @@ def select_sources(_clicks, current):
         sources_chip_label(selected),
         sources_menu(selected),
         count,
-        None,
     )
 
 

--- a/frontend/dash_app/components/composer.py
+++ b/frontend/dash_app/components/composer.py
@@ -5,10 +5,12 @@ from dash import dcc, html
 from frontend.dash_app import theme as t
 from frontend.dash_app.config import (
     COMPOSER_PLACEHOLDER,
+    DEFAULT_SOURCE_IDS,
     ID,
     MODELS,
     SOURCES,
     model_name,
+    sources_chip_label,
 )
 
 
@@ -146,60 +148,79 @@ def _model_picker(selected_id: str) -> html.Div:
     )
 
 
-def _sources_picker() -> html.Div:
-    # The knowledge base is Wikipedia-only: one collection, always selected.
-    rows = [
-        html.Div(
-            style={
-                "display": "flex",
-                "alignItems": "flex-start",
-                "gap": "11px",
-                "padding": "9px 10px",
-                "borderRadius": "9px",
-            },
-            children=[
-                html.Span(
-                    "✓",
-                    style={
-                        "flex": "none",
-                        "width": "18px",
-                        "height": "18px",
-                        "borderRadius": "5px",
-                        "background": t.ACCENT,
-                        "color": "#fff",
-                        "display": "inline-flex",
-                        "alignItems": "center",
-                        "justifyContent": "center",
-                        "fontSize": "11px",
-                        "marginTop": "1px",
-                    },
-                ),
-                html.Div(
-                    [
-                        html.Div(
-                            s["name"],
-                            style={
-                                "fontFamily": t.SANS,
-                                "fontWeight": 600,
-                                "fontSize": "13.5px",
-                                "color": t.INK,
-                            },
-                        ),
-                        html.Div(
-                            s["desc"],
-                            style={
-                                "fontFamily": t.SANS,
-                                "fontSize": "12px",
-                                "color": t.MUTED,
-                                "marginTop": "1px",
-                            },
-                        ),
-                    ]
-                ),
-            ],
+def sources_menu(selected_ids: list[str]) -> list:
+    """Rows for the sources picker; re-rendered on selection to update ticks."""
+    selected = set(selected_ids)
+    rows = []
+    for s in SOURCES:
+        active = s["id"] in selected
+        rows.append(
+            html.Div(
+                id={"type": "source-option", "index": s["id"]},
+                n_clicks=0,
+                className="menu-row",
+                style={
+                    "display": "flex",
+                    "alignItems": "flex-start",
+                    "gap": "11px",
+                    "padding": "9px 10px",
+                    "borderRadius": "9px",
+                    "cursor": "pointer",
+                    "background": "#f0e7d6" if active else "transparent",
+                },
+                children=[
+                    html.Span(
+                        "✓" if active else "",
+                        style={
+                            "flex": "none",
+                            "width": "18px",
+                            "height": "18px",
+                            "borderRadius": "5px",
+                            "background": t.ACCENT
+                            if active
+                            else "transparent",
+                            "border": (
+                                f"1px solid {t.ACCENT}"
+                                if not active
+                                else "none"
+                            ),
+                            "color": "#fff",
+                            "display": "inline-flex",
+                            "alignItems": "center",
+                            "justifyContent": "center",
+                            "fontSize": "11px",
+                            "marginTop": "1px",
+                        },
+                    ),
+                    html.Div(
+                        [
+                            html.Div(
+                                s["name"],
+                                style={
+                                    "fontFamily": t.SANS,
+                                    "fontWeight": 600,
+                                    "fontSize": "13.5px",
+                                    "color": t.INK,
+                                },
+                            ),
+                            html.Div(
+                                s["desc"],
+                                style={
+                                    "fontFamily": t.SANS,
+                                    "fontSize": "12px",
+                                    "color": t.MUTED,
+                                    "marginTop": "1px",
+                                },
+                            ),
+                        ]
+                    ),
+                ],
+            )
         )
-        for s in SOURCES
-    ]
+    return rows
+
+
+def _sources_picker(selected_ids: list[str]) -> html.Div:
     popover = html.Div(
         id=ID.SOURCES_POP,
         className="hidden",
@@ -216,10 +237,11 @@ def _sources_picker() -> html.Div:
                     "padding": "0 10px 8px",
                 },
             ),
-            *rows,
+            html.Div(id=ID.SOURCES_MENU, children=sources_menu(selected_ids)),
             html.Div(
-                html.Span(
-                    f"{len(SOURCES)} of {len(SOURCES)} selected",
+                id=f"{ID.SOURCES_MENU}-count",
+                children=html.Span(
+                    f"{len(selected_ids)} of {len(SOURCES)} selected",
                     style={
                         "fontFamily": t.SANS,
                         "fontSize": "12px",
@@ -238,9 +260,9 @@ def _sources_picker() -> html.Div:
         style={"position": "relative"},
         children=[
             _chip(
-                f"{ID.SOURCES_TRIGGER}-label",
+                ID.SOURCES_CHIP_LABEL,
                 ID.SOURCES_TRIGGER,
-                "Sources · All",
+                sources_chip_label(selected_ids),
             ),
             popover,
         ],
@@ -269,7 +291,9 @@ def _send_button() -> html.Div:
     )
 
 
-def composer(selected_model_id: str) -> html.Div:
+def composer(
+    selected_model_id: str, selected_source_ids: list[str]
+) -> html.Div:
     box = html.Div(
         style={
             "position": "relative",
@@ -312,7 +336,7 @@ def composer(selected_model_id: str) -> html.Div:
                 },
                 children=[
                     _model_picker(selected_model_id),
-                    _sources_picker(),
+                    _sources_picker(selected_source_ids),
                     _send_button(),
                 ],
             ),

--- a/frontend/dash_app/components/composer.py
+++ b/frontend/dash_app/components/composer.py
@@ -91,7 +91,6 @@ def model_menu(selected_id: str) -> list:
                     "padding": "9px 10px",
                     "borderRadius": "9px",
                     "cursor": "pointer",
-                    "background": "#f0e7d6" if active else "transparent",
                 },
                 children=[
                     html.Div(
@@ -166,7 +165,6 @@ def sources_menu(selected_ids: list[str]) -> list:
                     "padding": "9px 10px",
                     "borderRadius": "9px",
                     "cursor": "pointer",
-                    "background": "#f0e7d6" if active else "transparent",
                 },
                 children=[
                     html.Span(

--- a/frontend/dash_app/config.py
+++ b/frontend/dash_app/config.py
@@ -68,17 +68,34 @@ def model_name(model_id: str) -> str:
 
 
 # --- Source collections ------------------------------------------------------
-# The knowledge base is Wikipedia-only, so there is a single, always-on
-# collection. The picker exists to mirror the design and make the scope of the
-# archive explicit.
 SOURCES = [
     {
         "id": "wikipedia",
         "name": "Wikipedia",
         "desc": "Crowd-sourced encyclopedia articles",
     },
+    {
+        "id": "miller_center",
+        "name": "Miller Center",
+        "desc": "Scholarly essays from the University of Virginia",
+    },
 ]
-SOURCE_LABEL = "Wikipedia"  # shown on each source card's collection tag
+DEFAULT_SOURCE_IDS = [s["id"] for s in SOURCES]
+SOURCE_NAMES = {s["id"]: s["name"] for s in SOURCES}
+
+
+def source_collection_name(source_id: str) -> str:
+    """Human-facing name for a collection id."""
+    return SOURCE_NAMES.get(source_id, source_id.replace("_", " ").title())
+
+
+def sources_chip_label(selected_ids: list[str]) -> str:
+    """Composer chip text for the current source selection."""
+    if len(selected_ids) == len(SOURCES):
+        return "Sources · All"
+    if len(selected_ids) == 1:
+        return f"Sources · {source_collection_name(selected_ids[0])}"
+    return f"Sources · {len(selected_ids)}"
 
 
 # --- Element ids -------------------------------------------------------------
@@ -86,6 +103,7 @@ class ID:
     # stores
     CONVERSATION = "conv-store"  # active conversation id
     MODEL = "model-store"  # selected model id
+    SOURCES = "sources-store"  # selected source collection ids
     PENDING = "pending-store"  # in-flight query (drives the agent run)
     POPOVER = "popover-store"  # name of the open popover, or None
     SCROLL_DUMMY = "scroll-dummy"  # autoscroll callback sink
@@ -112,7 +130,9 @@ class ID:
     MODEL_POP = "model-pop"
     MODEL_MENU = "model-menu"
     SOURCES_TRIGGER = "sources-trigger"
+    SOURCES_CHIP_LABEL = "sources-chip-label"
     SOURCES_POP = "sources-pop"
+    SOURCES_MENU = "sources-menu"
 
 
 # Popover names (values stored in ID.POPOVER)

--- a/frontend/dash_app/main.py
+++ b/frontend/dash_app/main.py
@@ -21,7 +21,12 @@ from frontend.dash_app import theme as t
 from frontend.dash_app.components.composer import composer
 from frontend.dash_app.components.header import header
 from frontend.dash_app.components.welcome import welcome
-from frontend.dash_app.config import APP_NAME, DEFAULT_MODEL_ID, ID
+from frontend.dash_app.config import (
+    APP_NAME,
+    DEFAULT_MODEL_ID,
+    DEFAULT_SOURCE_IDS,
+    ID,
+)
 
 # Configure logfire before the app is built so the agent's instrumentation
 # (frontend.agent's Instrumentation capability) is exported on every run.
@@ -52,6 +57,7 @@ def _stores() -> list:
     return [
         dcc.Store(id=ID.CONVERSATION, data=None),
         dcc.Store(id=ID.MODEL, data=DEFAULT_MODEL_ID),
+        dcc.Store(id=ID.SOURCES, data=DEFAULT_SOURCE_IDS),
         dcc.Store(id=ID.PENDING, data=None),
         dcc.Store(id=ID.POPOVER, data=None),
         dcc.Store(id=ID.SCROLL_DUMMY),
@@ -75,7 +81,7 @@ app.layout = html.Div(
             style={"flex": "1", "overflow": "auto"},
             children=html.Div(id=ID.CHAT_CONTENT, children=welcome()),
         ),
-        composer(DEFAULT_MODEL_ID),
+        composer(DEFAULT_MODEL_ID, DEFAULT_SOURCE_IDS),
         # Full-screen click target that closes any open popover.
         html.Div(
             id=ID.BACKDROP,

--- a/frontend/dash_app/services/conversation.py
+++ b/frontend/dash_app/services/conversation.py
@@ -18,7 +18,11 @@ from pydantic_ai.usage import UsageLimits
 from backend.schemas import RetrievedChunk
 from frontend.agent import REQUEST_LIMIT, AgentDeps, agent, parse_agent_run
 from frontend.client import RAGClient
-from frontend.dash_app.config import ABSTAIN_TEXT, ERROR_TEXT, SOURCE_LABEL
+from frontend.dash_app.config import (
+    ABSTAIN_TEXT,
+    ERROR_TEXT,
+    source_collection_name,
+)
 
 
 def prettify_source(source: str) -> str:
@@ -43,8 +47,8 @@ class SourceView:
     def from_chunk(cls, n: int, chunk: RetrievedChunk) -> "SourceView":
         return cls(
             n=n,
-            name=prettify_source(chunk.source),
-            collection=SOURCE_LABEL,
+            name=prettify_source(chunk.document),
+            collection=source_collection_name(chunk.source),
             excerpt=chunk.text.strip(),
         )
 
@@ -116,13 +120,20 @@ class ConversationStore:
             DisplayMessage(id=conv.next_id(), role="user", text=text)
         )
 
-    def run_assistant(self, conv_id: str, query: str, model_id: str) -> None:
+    def run_assistant(
+        self,
+        conv_id: str,
+        query: str,
+        model_id: str,
+        sources: list[str],
+    ) -> None:
         """Run one agentic loop and append the assistant's turn.
 
         Failures (e.g. a missing provider API key) are caught and surfaced as a
         friendly error message rather than crashing the callback.
         """
         conv = self.get(conv_id)
+        conv.deps.sources = sources
         try:
             result = agent.run_sync(
                 query,

--- a/frontend/dash_app/services/conversation.py
+++ b/frontend/dash_app/services/conversation.py
@@ -25,12 +25,33 @@ from frontend.dash_app.config import (
 )
 
 
-def prettify_source(source: str) -> str:
-    """Turn a ``source`` slug into a display name.
+def _prettify_miller_center_document(name: str) -> str:
+    """Format a Miller Center filename stem as a readable title.
 
-    e.g. ``andrew_johnson.txt`` -> ``Andrew Johnson``.
+    Mirrors ``build_filename`` in ``scripts/scrape_miller_center.py``:
+    ``{number}_{president}_{subpage_index}_{subpage}``
     """
-    name = source[:-4] if source.lower().endswith(".txt") else source
+    parts = name.split("_")
+    if len(parts) < 4 or not parts[0].isdigit() or not parts[-2].isdigit():
+        return name.replace("_", " ").replace("-", " ").strip().title()
+
+    president = "_".join(parts[1:-2])
+    subpage = parts[-1]
+    text = f"{president} {subpage}".replace("_", " ").replace("-", " ")
+    return text.strip().title()
+
+
+def prettify_source(document: str, collection: str | None = None) -> str:
+    """Turn a document filename into a display name.
+
+    Wikipedia: ``andrew_johnson.txt`` -> ``Andrew Johnson``.
+
+    Miller Center: ``10_john_tyler_5_life-after-the-presidency.txt`` ->
+    ``John Tyler Life After The Presidency``.
+    """
+    name = document[:-4] if document.lower().endswith(".txt") else document
+    if collection == "miller_center":
+        return _prettify_miller_center_document(name)
     return name.replace("_", " ").strip().title()
 
 
@@ -47,7 +68,7 @@ class SourceView:
     def from_chunk(cls, n: int, chunk: RetrievedChunk) -> "SourceView":
         return cls(
             n=n,
-            name=prettify_source(chunk.document),
+            name=prettify_source(chunk.document, chunk.source),
             collection=source_collection_name(chunk.source),
             excerpt=chunk.text.strip(),
         )


### PR DESCRIPTION
## Summary

Wires the composer’s **Sources** picker through to retrieval so users can scope each turn to Wikipedia, the Miller Center, or both. Also improves how Miller Center citations are displayed in the transcript.

The retrieval API previously accepted a single `source` filter; the agent and Dash UI ignored source selection entirely.

## Changes

### Retrieval API
- `RetrieveRequest.source` → `sources: list[str] | None`
- `retrieve()` filters with `WHERE source IN (...)`; `None` searches all collections

### Agent
- `AgentDeps.sources` holds the per-turn collection policy (set before each `run_sync`)
- `search_knowledge_base` passes `deps.sources` to the retrieval client
- Model selection was already per-turn via `run_sync(model=...)`; sources follow the same pattern through deps

### Dash UI
- Interactive multi-select sources picker (Wikipedia + Miller Center; at least one required)
- Selection flows: composer → `sources-store` → `pending-store` → `run_assistant` → `AgentDeps`
- Source cards show the correct collection label and document name

### Source card titles
- Miller Center filenames (`10_john_tyler_5_life-after-the-presidency.txt`) are parsed into readable titles (`John Tyler Life After The Presidency`), matching the scrape filename convention

### Deploy config
- Bumps `VECTOR_STORE_CONFIG_ID` in `backend/server.py` to point at the updated vector store

## Test plan

- [ ] Deploy/restart the Modal retrieval server (API contract changed: `source` → `sources`)
- [ ] Select Wikipedia only → agent retrieves only Wikipedia chunks
- [ ] Select Miller Center only → agent retrieves only Miller Center chunks
- [ ] Select both → agent searches across both collections
- [ ] Change sources between turns in the same conversation
- [ ] Verify Miller Center source cards show readable titles and correct collection labels