### PR TITLE
Use T4 GPU on backend server (~same cold-start but 12X faster inference)

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -47,7 +47,7 @@ volume = modal.Volume.from_name(MODAL_VOLUME_NAME)
     image=image,
     volumes={"/data": volume},
     secrets=[db_secret],
-    cpu=1,
+    gpu="T4",
     scaledown_window=600,
 )
 class Server:


### PR DESCRIPTION
Use GPUs in backend Modal server. The underlying models (embedding model + reranker model) are small, so T4 is sufficient and right-sized.