### PR TITLE
Proactive server start

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -49,6 +49,7 @@ volume = modal.Volume.from_name(MODAL_VOLUME_NAME)
     secrets=[db_secret],
     gpu="T4",
     scaledown_window=600,
+    max_containers=1,
 )
 class Server:
     """Serves vector retrieval and cross-encoder reranking."""

--- a/frontend/client.py
+++ b/frontend/client.py
@@ -47,6 +47,20 @@ class RAGClient:
         self.prompt_template = jinja2.Template(PROMPT_TEMPLATE)
         self.openai_client = OpenAI(api_key=API_KEY)
 
+    def is_healthy(self, timeout: float = 4.0) -> bool:
+        """Whether the server's ``/health`` endpoint responds OK.
+
+        Drives the warm-up indicator. A cold-starting server holds the request
+        until its container is ready, so a timeout here means "still warming",
+        not necessarily "down" — callers distinguish a genuine outage by how
+        long the failures persist.
+        """
+        try:
+            response = self.http_client.get("/health", timeout=timeout)
+            return response.status_code == 200
+        except httpx.HTTPError:
+            return False
+
     def retrieve(
         self,
         query: str,

--- a/frontend/client.py
+++ b/frontend/client.py
@@ -43,7 +43,7 @@ DOCUMENT {{ loop.index }}
 
 class RAGClient:
     def __init__(self) -> None:
-        self.http_client = httpx.Client(base_url=SERVER_URL, timeout=30.0)
+        self.http_client = httpx.Client(base_url=SERVER_URL, timeout=60.0)
         self.prompt_template = jinja2.Template(PROMPT_TEMPLATE)
         self.openai_client = OpenAI(api_key=API_KEY)
 

--- a/frontend/dash_app/assets/app.css
+++ b/frontend/dash_app/assets/app.css
@@ -26,6 +26,23 @@ body { background: #f4efe4; }
   animation: archiveDots 1.1s infinite ease-in-out;
 }
 
+/* --- Server status indicator --- */
+.server-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  display: inline-block;
+}
+.server-dot--warming {
+  background: #c0892f; /* warm amber: work in progress */
+  animation: serverPulse 1.2s infinite ease-in-out;
+}
+.server-dot--down { background: #b8958c; } /* muted: unavailable */
+@keyframes serverPulse {
+  0%, 100% { opacity: .3; transform: scale(.8); }
+  50% { opacity: 1; transform: scale(1); }
+}
+
 /* --- Answer markdown --- */
 .answer-md {
   font-family: 'Spectral', Georgia, serif;

--- a/frontend/dash_app/callbacks.py
+++ b/frontend/dash_app/callbacks.py
@@ -30,6 +30,7 @@ from dash.exceptions import PreventUpdate
 from frontend.dash_app import theme as t
 from frontend.dash_app.components.composer import model_menu, sources_menu
 from frontend.dash_app.components.conversation import render_conversation
+from frontend.dash_app.components.header import server_status_content
 from frontend.dash_app.components.welcome import welcome
 from frontend.dash_app.config import (
     DEFAULT_MODEL_ID,
@@ -118,6 +119,34 @@ def run_agent(pending):
     )
     conv = store.get(pending["conv_id"])
     return render_conversation(conv, loading=False), None
+
+
+# --- Server warm-up status ---------------------------------------------------
+# How long to keep polling /health before declaring the server unavailable.
+# A cold start takes ~30s; persistent failure well beyond that means the server
+# is genuinely down (bad SERVER_URL, app not deployed) rather than warming.
+WARMUP_MAX_ATTEMPTS = 40  # ~2 min at the 3s poll interval
+
+
+@callback(
+    Output(ID.SERVER_STATUS, "children"),
+    Output(ID.SERVER_POLL, "disabled"),
+    Input(ID.SERVER_POLL, "n_intervals"),
+    prevent_initial_call=False,
+)
+def poll_server_status(n_intervals):
+    """Poll the retrieval server's health and drive the header indicator.
+
+    The first tick fires on page load and wakes a cold server. We keep showing
+    "warming" while requests fail, flip to "ready" on the first healthy
+    response, or give up with "unavailable" once the retry budget is spent —
+    disabling the poll in either terminal state so it stays put.
+    """
+    if store.is_server_healthy():
+        return server_status_content("ready"), True
+    if (n_intervals or 0) >= WARMUP_MAX_ATTEMPTS:
+        return server_status_content("unavailable"), True
+    return server_status_content("warming"), False
 
 
 # --- New conversation --------------------------------------------------------

--- a/frontend/dash_app/components/header.py
+++ b/frontend/dash_app/components/header.py
@@ -11,6 +11,67 @@ from frontend.dash_app.config import (
     ID,
 )
 
+SERVER_STATUS_LABELS = {
+    "warming": "Server: Warming up",
+    "ready": "Server: Ready",
+    "unavailable": "Server: Unavailable",
+}
+
+
+def _server_status_mark(state: str) -> html.Span:
+    """The leading glyph: a pulsing dot while warming, otherwise static."""
+    if state == "ready":
+        return html.Span(
+            "✓",
+            style={
+                "color": t.ACCENT,
+                "fontSize": "12px",
+                "fontWeight": 700,
+                "lineHeight": "1",
+            },
+        )
+    cls = (
+        "server-dot server-dot--down"
+        if state == "unavailable"
+        else "server-dot server-dot--warming"
+    )
+    return html.Span(className=cls)
+
+
+def server_status_content(state: str) -> list:
+    """Inner ``[mark, label]`` for the header server-status indicator.
+
+    Shared by the initial render and the polling callback so both produce an
+    identical structure for each ``state`` ("warming" | "ready" |
+    "unavailable").
+    """
+    label = SERVER_STATUS_LABELS.get(state, SERVER_STATUS_LABELS["warming"])
+    return [
+        _server_status_mark(state),
+        html.Span(
+            label,
+            style={
+                "fontFamily": t.SANS,
+                "fontWeight": 500,
+                "fontSize": "13px",
+                "color": t.MUTED,
+            },
+        ),
+    ]
+
+
+def server_status(state: str = "warming") -> html.Div:
+    """Header indicator reporting whether the retrieval server is warm."""
+    return html.Div(
+        id=ID.SERVER_STATUS,
+        style={
+            "display": "inline-flex",
+            "alignItems": "center",
+            "gap": "7px",
+        },
+        children=server_status_content(state),
+    )
+
 
 def _about_popover() -> html.Div:
     return html.Div(
@@ -200,6 +261,7 @@ def header() -> html.Div:
                     "gap": "14px",
                 },
                 children=[
+                    server_status(),
                     html.Div(
                         style={"position": "relative"},
                         children=[

--- a/frontend/dash_app/config.py
+++ b/frontend/dash_app/config.py
@@ -108,6 +108,7 @@ class ID:
     POPOVER = "popover-store"  # name of the open popover, or None
     SCROLL_DUMMY = "scroll-dummy"  # autoscroll callback sink
     RESIZE_DUMMY = "resize-dummy"  # textarea autosize callback sink
+    SERVER_POLL = "server-poll"  # interval that polls server health
 
     # layout
     CHAT_SCROLL = "chat-scroll"
@@ -115,6 +116,7 @@ class ID:
     BACKDROP = "backdrop"
 
     # header
+    SERVER_STATUS = "server-status"  # warm-up indicator container
     ABOUT_TRIGGER = "about-trigger"
     ABOUT_POP = "about-pop"
     NEW_TRIGGER = "new-trigger"

--- a/frontend/dash_app/main.py
+++ b/frontend/dash_app/main.py
@@ -62,6 +62,7 @@ def _stores() -> list:
         dcc.Store(id=ID.POPOVER, data=None),
         dcc.Store(id=ID.SCROLL_DUMMY),
         dcc.Store(id=ID.RESIZE_DUMMY),
+        dcc.Interval(id=ID.SERVER_POLL, interval=3000, n_intervals=0),
     ]
 
 

--- a/frontend/dash_app/services/conversation.py
+++ b/frontend/dash_app/services/conversation.py
@@ -130,6 +130,10 @@ class ConversationStore:
         conv = self._conversations.get(conv_id) if conv_id else None
         return bool(conv and conv.display)
 
+    def is_server_healthy(self) -> bool:
+        """Whether the retrieval server is warm and ready to serve requests."""
+        return self._client.is_healthy()
+
     def reset(self, conv_id: str) -> None:
         """Forget a conversation so the next message starts a clean thread."""
         with self._lock:


### PR DESCRIPTION
## Proactively warm the backend and surface server status in the UI

### Summary

The Modal retrieval backend cold-starts in ~30s. Previously the app waited for the first user query to trigger that cold start, so the first question was always slow. This branch proactively warms the server on page load and adds a header indicator so users can see when the backend is ready.

### What changed

- **Proactive warm-up.** On page load, a `dcc.Interval` poller pings the backend's `/health` endpoint (`backend/server.py`), which triggers the Modal container's cold start while the user reads the welcome screen / composes their first question—hiding most of the latency.
- **Header status indicator.** A new `Server: …` indicator in the header with three states:
  - **Warming up** — pulsing amber dot while `/health` is failing/pending.
  - **Ready** — static maroon check on the first healthy response; persists.
  - **Unavailable** — shown if the server never responds within the retry budget (~2 min), distinguishing a genuine outage from a normal cold start.
  - Polling stops once a terminal state is reached.
- **Longer client timeout.** Bumped the `RAGClient` HTTP timeout from 30s → 60s so a query that races a cold start doesn't error at the boundary.

### Implementation notes

- `RAGClient.is_healthy()` + a `ConversationStore.is_server_healthy()` accessor back the poll.
- The indicator's three states are rendered by `server_status()` / `server_status_content()` in `components/header.py`, with pulsing-dot styles in `assets/app.css`.
- A single callback (`poll_server_status`) drives the indicator off `dcc.Interval`'s `n_intervals` and disables the interval in terminal states.

### Known limitation

Because polling stops at "Ready", if the container later scales down while the user keeps the tab open, the indicator goes stale (still shows "Ready") until a reload.
