### PR TITLE
UI polish

### DIFF
--- a/frontend/dash_app/assets/app.css
+++ b/frontend/dash_app/assets/app.css
@@ -80,8 +80,8 @@ body { background: #f4efe4; }
 .hover-ink { transition: color .12s ease; }
 .hover-ink:hover { color: #5e5141; }
 
-.hover-accent-fill { transition: background-color .12s ease; }
-.hover-accent-fill:hover { background: #6b332d; } /* ACCENT_HOVER */
+.hover-icon-fill { background: #8a7c66; transition: background-color .12s ease; } /* MUTED */
+.hover-icon-fill:hover { background: #7c3b34; } /* ACCENT */
 
 .hover-border { transition: border-color .12s ease; }
 .hover-border:hover { border-color: #d2c3a2; }

--- a/frontend/dash_app/assets/app.css
+++ b/frontend/dash_app/assets/app.css
@@ -80,6 +80,9 @@ body { background: #f4efe4; }
 .hover-ink { transition: color .12s ease; }
 .hover-ink:hover { color: #5e5141; }
 
+.hover-accent-fill { transition: background-color .12s ease; }
+.hover-accent-fill:hover { background: #6b332d; } /* ACCENT_HOVER */
+
 .hover-border { transition: border-color .12s ease; }
 .hover-border:hover { border-color: #d2c3a2; }
 

--- a/frontend/dash_app/callbacks.py
+++ b/frontend/dash_app/callbacks.py
@@ -28,8 +28,8 @@ from dash import (
 from dash.exceptions import PreventUpdate
 
 from frontend.dash_app import theme as t
+from frontend.dash_app.components.chat import render_chat
 from frontend.dash_app.components.composer import model_menu, sources_menu
-from frontend.dash_app.components.conversation import render_conversation
 from frontend.dash_app.components.header import server_status_content
 from frontend.dash_app.components.welcome import welcome
 from frontend.dash_app.config import (
@@ -45,7 +45,7 @@ from frontend.dash_app.config import (
     model_name,
     sources_chip_label,
 )
-from frontend.dash_app.services.conversation import store
+from frontend.dash_app.services.chat import store
 
 
 # --- Sending a message -------------------------------------------------------
@@ -53,19 +53,19 @@ from frontend.dash_app.services.conversation import store
     Output(ID.CHAT_CONTENT, "children"),
     Output(ID.INPUT, "value"),
     Output(ID.PENDING, "data"),
-    Output(ID.CONVERSATION, "data"),
+    Output(ID.CHAT, "data"),
     Output(ID.POPOVER, "data", allow_duplicate=True),
     Input(ID.SEND, "n_clicks"),
     Input({"type": "example-prompt", "index": ALL}, "n_clicks"),
     State(ID.INPUT, "value"),
-    State(ID.CONVERSATION, "data"),
+    State(ID.CHAT, "data"),
     State(ID.MODEL, "data"),
     State(ID.SOURCES, "data"),
     State(ID.PENDING, "data"),
     prevent_initial_call=True,
 )
 def submit(
-    send_clicks, _example_clicks, text, conv_id, model_id, source_ids, pending
+    send_clicks, _example_clicks, text, chat_id, model_id, source_ids, pending
 ):
     if pending:  # a run is already in flight; ignore further submits
         raise PreventUpdate
@@ -86,20 +86,20 @@ def submit(
     if not query:
         raise PreventUpdate
 
-    conv_id = conv_id or uuid.uuid4().hex
+    chat_id = chat_id or uuid.uuid4().hex
     model_id = model_id or DEFAULT_MODEL_ID
     source_ids = source_ids or DEFAULT_SOURCE_IDS
-    store.add_user_message(conv_id, query)
+    store.add_user_message(chat_id, query)
 
-    conv = store.get(conv_id)
-    children = render_conversation(conv, loading=True)
+    chat = store.get(chat_id)
+    children = render_chat(chat, loading=True)
     pending = {
-        "conv_id": conv_id,
+        "chat_id": chat_id,
         "query": query,
         "model": model_id,
         "sources": source_ids,
     }
-    return children, "", pending, conv_id, None
+    return children, "", pending, chat_id, None
 
 
 @callback(
@@ -112,13 +112,13 @@ def run_agent(pending):
     if not pending:
         raise PreventUpdate
     store.run_assistant(
-        pending["conv_id"],
+        pending["chat_id"],
         pending["query"],
         pending["model"],
         pending["sources"],
     )
-    conv = store.get(pending["conv_id"])
-    return render_conversation(conv, loading=False), None
+    chat = store.get(pending["chat_id"])
+    return render_chat(chat, loading=False), None
 
 
 # --- Server warm-up status ---------------------------------------------------
@@ -149,21 +149,21 @@ def poll_server_status(n_intervals):
     return server_status_content("warming"), False
 
 
-# --- New conversation --------------------------------------------------------
+# --- New chat --------------------------------------------------------
 @callback(
     Output(ID.CHAT_CONTENT, "children", allow_duplicate=True),
-    Output(ID.CONVERSATION, "data", allow_duplicate=True),
+    Output(ID.CHAT, "data", allow_duplicate=True),
     Output(ID.PENDING, "data", allow_duplicate=True),
     Output(ID.POPOVER, "data", allow_duplicate=True),
     Input(ID.CONFIRM_NEW, "n_clicks"),
-    State(ID.CONVERSATION, "data"),
+    State(ID.CHAT, "data"),
     prevent_initial_call=True,
 )
-def confirm_new(n_clicks, conv_id):
+def confirm_new(n_clicks, chat_id):
     if not n_clicks:
         raise PreventUpdate
-    if conv_id:
-        store.reset(conv_id)
+    if chat_id:
+        store.reset(chat_id)
     return welcome(), uuid.uuid4().hex, None, None
 
 
@@ -229,17 +229,17 @@ def select_sources(_clicks, current):
     Input(ID.BACKDROP, "n_clicks"),
     Input(ID.CANCEL_NEW, "n_clicks"),
     State(ID.POPOVER, "data"),
-    State(ID.CONVERSATION, "data"),
+    State(ID.CHAT, "data"),
     prevent_initial_call=True,
 )
-def toggle_popover(_a, _n, _m, _s, _bd, _cancel, current, conv_id):
+def toggle_popover(_a, _n, _m, _s, _bd, _cancel, current, chat_id):
     trigger = ctx.triggered_id
     if trigger in (ID.BACKDROP, ID.CANCEL_NEW):
         return None
 
     if trigger == ID.NEW_TRIGGER:
         # Nothing to clear → no confirmation needed.
-        target = POP_NEWCONFIRM if store.has_messages(conv_id) else None
+        target = POP_NEWCONFIRM if store.has_messages(chat_id) else None
     else:
         target = {
             ID.ABOUT_TRIGGER: POP_ABOUT,

--- a/frontend/dash_app/components/chat.py
+++ b/frontend/dash_app/components/chat.py
@@ -1,14 +1,10 @@
-"""Renders a conversation transcript: user bubbles, answers and sources."""
+"""Renders a chat transcript: user bubbles, answers and sources."""
 
 from dash import dcc, html
 
 from frontend.dash_app import theme as t
 from frontend.dash_app.config import ABSTAIN_TEXT, LOADING_TEXT
-from frontend.dash_app.services.conversation import (
-    Conversation,
-    DisplayMessage,
-    SourceView,
-)
+from frontend.dash_app.services.chat import Chat, DisplayMessage, SourceView
 
 
 def _avatar() -> html.Div:
@@ -238,10 +234,10 @@ def _loading() -> html.Div:
     )
 
 
-def render_conversation(conv: Conversation, loading: bool) -> html.Div:
+def render_chat(chat: Chat, loading: bool) -> html.Div:
     """Render the full transcript, with a loading bubble when a run is in flight."""
     children = []
-    for msg in conv.display:
+    for msg in chat.display:
         if msg.role == "user":
             children.append(_user_message(msg))
         else:

--- a/frontend/dash_app/components/composer.py
+++ b/frontend/dash_app/components/composer.py
@@ -225,16 +225,6 @@ def _sources_picker(selected_ids: list[str]) -> html.Div:
         style={**_up_popover(330)},
         children=[
             _menu_label("Sources"),
-            html.Div(
-                "Choose which collections the agent searches.",
-                style={
-                    "fontFamily": t.SANS,
-                    "fontSize": "12px",
-                    "lineHeight": 1.4,
-                    "color": t.MUTED,
-                    "padding": "0 10px 8px",
-                },
-            ),
             html.Div(id=ID.SOURCES_MENU, children=sources_menu(selected_ids)),
             html.Div(
                 id=f"{ID.SOURCES_MENU}-count",

--- a/frontend/dash_app/components/header.py
+++ b/frontend/dash_app/components/header.py
@@ -77,7 +77,7 @@ def _about_popover() -> html.Div:
     return html.Div(
         id=ID.ABOUT_POP,
         className="hidden",
-        style=t.popover(360),
+        style={**t.popover(360), "right": "auto", "left": 0},
         children=[
             html.Div(
                 "About this project",
@@ -203,24 +203,6 @@ def _newconfirm_popover() -> html.Div:
 
 
 def header() -> html.Div:
-    info_badge = html.Span(
-        "i",
-        style={
-            "width": "16px",
-            "height": "16px",
-            "borderRadius": "50%",
-            "border": "1.5px solid #b6a587",
-            "color": t.MUTED,
-            "fontFamily": "Georgia, serif",
-            "fontStyle": "italic",
-            "fontWeight": 700,
-            "fontSize": "10px",
-            "display": "inline-flex",
-            "alignItems": "center",
-            "justifyContent": "center",
-        },
-    )
-
     return html.Div(
         style={
             "flex": "none",
@@ -251,6 +233,42 @@ def header() -> html.Div:
                             "letterSpacing": ".2px",
                         },
                     ),
+                    # Filled-accent info circle: a quiet but visible entry point
+                    # to the "About this project" popover.
+                    html.Div(
+                        style={
+                            "position": "relative",
+                            "display": "inline-flex",
+                            "alignItems": "center",
+                        },
+                        children=[
+                            html.Div(
+                                "i",
+                                id=ID.ABOUT_TRIGGER,
+                                n_clicks=0,
+                                title="How it works",
+                                className="hover-accent-fill",
+                                style={
+                                    "width": "18px",
+                                    "height": "18px",
+                                    "borderRadius": "50%",
+                                    "background": t.ACCENT,
+                                    "color": t.ON_ACCENT,
+                                    "fontFamily": "Georgia, serif",
+                                    "fontStyle": "italic",
+                                    "fontWeight": 700,
+                                    "fontSize": "11px",
+                                    "lineHeight": "1",
+                                    "display": "inline-flex",
+                                    "alignItems": "center",
+                                    "justifyContent": "center",
+                                    "cursor": "pointer",
+                                    "flex": "none",
+                                },
+                            ),
+                            _about_popover(),
+                        ],
+                    ),
                 ],
             ),
             # actions
@@ -262,28 +280,6 @@ def header() -> html.Div:
                 },
                 children=[
                     server_status(),
-                    html.Div(
-                        style={"position": "relative"},
-                        children=[
-                            html.Div(
-                                [info_badge, " About"],
-                                id=ID.ABOUT_TRIGGER,
-                                n_clicks=0,
-                                className="hover-ink",
-                                style={
-                                    "display": "inline-flex",
-                                    "alignItems": "center",
-                                    "gap": "6px",
-                                    "fontFamily": t.SANS,
-                                    "fontWeight": 500,
-                                    "fontSize": "13px",
-                                    "color": t.MUTED,
-                                    "cursor": "pointer",
-                                },
-                            ),
-                            _about_popover(),
-                        ],
-                    ),
                     html.Div(
                         style={"position": "relative"},
                         children=[

--- a/frontend/dash_app/components/header.py
+++ b/frontend/dash_app/components/header.py
@@ -1,4 +1,4 @@
-"""Top bar: brand mark, About popover and New-conversation control."""
+"""Top bar: brand mark, About popover and New-chat control."""
 
 from dash import dcc, html
 
@@ -138,10 +138,10 @@ def _newconfirm_popover() -> html.Div:
     return html.Div(
         id=ID.NEWCONFIRM_POP,
         className="hidden",
-        style={**t.popover(290), "borderRadius": "13px", "padding": "16px"},
+        style={**t.popover(320), "borderRadius": "13px", "padding": "16px"},
         children=[
             html.Div(
-                "Start a new conversation?",
+                "Start a new chat?",
                 style={
                     "fontFamily": t.SANS,
                     "fontWeight": 600,
@@ -168,7 +168,9 @@ def _newconfirm_popover() -> html.Div:
                         n_clicks=0,
                         style={
                             "flex": "1",
-                            "textAlign": "center",
+                            "display": "flex",
+                            "alignItems": "center",
+                            "justifyContent": "center",
                             "border": f"1px solid {t.BORDER_SOFT}",
                             "borderRadius": "9px",
                             "padding": "8px",
@@ -180,11 +182,14 @@ def _newconfirm_popover() -> html.Div:
                         },
                     ),
                     html.Div(
-                        "New conversation",
+                        "New chat",
                         id=ID.CONFIRM_NEW,
                         n_clicks=0,
                         style={
                             "flex": "1",
+                            "display": "flex",
+                            "alignItems": "center",
+                            "justifyContent": "center",
                             "textAlign": "center",
                             "background": t.ACCENT,
                             "color": t.ON_ACCENT,
@@ -292,7 +297,7 @@ def header() -> html.Div:
                                             "color": t.ACCENT,
                                         },
                                     ),
-                                    " New conversation",
+                                    " New chat",
                                 ],
                                 id=ID.NEW_TRIGGER,
                                 n_clicks=0,

--- a/frontend/dash_app/components/header.py
+++ b/frontend/dash_app/components/header.py
@@ -228,7 +228,7 @@ def header() -> html.Div:
                         style={
                             "fontFamily": t.SERIF,
                             "fontWeight": 600,
-                            "fontSize": "18px",
+                            "fontSize": "20px",
                             "color": t.INK,
                             "letterSpacing": ".2px",
                         },
@@ -247,12 +247,11 @@ def header() -> html.Div:
                                 id=ID.ABOUT_TRIGGER,
                                 n_clicks=0,
                                 title="How it works",
-                                className="hover-accent-fill",
+                                className="hover-icon-fill",
                                 style={
                                     "width": "18px",
                                     "height": "18px",
                                     "borderRadius": "50%",
-                                    "background": t.ACCENT,
                                     "color": t.ON_ACCENT,
                                     "fontFamily": "Georgia, serif",
                                     "fontStyle": "italic",

--- a/frontend/dash_app/config.py
+++ b/frontend/dash_app/config.py
@@ -4,8 +4,6 @@ Copy, the model registry, the source collections and all element ids live
 here so components and callbacks share one vocabulary.
 """
 
-from frontend.agent import MODEL
-
 # --- Copy --------------------------------------------------------------------
 APP_NAME = "Presidential Archive"
 GITHUB_URL = "https://github.com/justinpyron/presidents-rag"
@@ -35,9 +33,9 @@ ERROR_TEXT = (
 
 # --- Models ------------------------------------------------------------------
 # The picker overrides the model per run. ``id`` is the Pydantic AI model
-# string passed to ``agent.run_sync(model=...)``. The default tracks the model
-# the agent is configured with, so the app works out of the box with only an
-# OpenAI key; Claude and Gemini require ANTHROPIC_API_KEY / GEMINI_API_KEY.
+# string passed to ``agent.run_sync(model=...)``.
+DEFAULT_MODEL_ID = "openai:gpt-5.4-mini"
+
 MODELS = [
     {
         "id": "anthropic:claude-sonnet-4-5",
@@ -45,7 +43,7 @@ MODELS = [
         "desc": "Balanced reasoning & speed",
     },
     {
-        "id": MODEL,  # "openai:gpt-5.4-mini"
+        "id": DEFAULT_MODEL_ID,
         "name": "GPT-5.4 mini",
         "desc": "OpenAI flagship, fast & grounded",
     },
@@ -55,7 +53,6 @@ MODELS = [
         "desc": "Long-context reasoning",
     },
 ]
-DEFAULT_MODEL_ID = MODEL
 
 
 def model_name(model_id: str) -> str:

--- a/frontend/dash_app/config.py
+++ b/frontend/dash_app/config.py
@@ -11,10 +11,9 @@ APP_NAME = "Presidential Archive"
 GITHUB_URL = "https://github.com/justinpyron/presidents-rag"
 
 ABOUT_LEAD = (
-    "Presidential Archive is a personal project exploring agentic "
-    "retrieval-augmented generation. Ask a question and the agent composes its "
-    "own searches over an encyclopedia of the U.S. presidents, reads what it "
-    "finds, and writes an answer you can trace back to its sources."
+    "Presidential Archive is an agentic RAG system. "
+    "Ask a question and an AI agent composes its own searches over a knowledge base of "
+    "the U.S. presidents, reads what it finds, and writes an answer you can trace back to its sources."
 )
 ABOUT_BUILT_WITH = "Built with Pydantic AI & Dash."
 

--- a/frontend/dash_app/config.py
+++ b/frontend/dash_app/config.py
@@ -17,18 +17,15 @@ ABOUT_LEAD = (
 )
 ABOUT_BUILT_WITH = "Built with Pydantic AI & Dash."
 
-WELCOME_HEADING = "A reference desk for the U.S. presidents"
-WELCOME_SUBTEXT = (
-    "Ask anything about the presidents. Every answer is drawn from encyclopedia "
-    "articles, with its sources kept close at hand."
-)
+WELCOME_HEADING = "A reference desk for American presidents"
+WELCOME_SUBTEXT = "Ask anything about the presidents. An answer grounded in reliable sources is returned."
 EXAMPLE_PROMPTS = [
     "Who succeeded the president who purchased Alaska?",
     "Which U.S. president was the tallest?",
     "Compare the Monroe and Truman doctrines.",
 ]
 
-COMPOSER_PLACEHOLDER = "Ask about any U.S. president…"
+COMPOSER_PLACEHOLDER = "Ask a queestion…"
 LOADING_TEXT = "Searching the archive"
 ABSTAIN_TEXT = "No grounded sources matched this question."
 ERROR_TEXT = (

--- a/frontend/dash_app/config.py
+++ b/frontend/dash_app/config.py
@@ -38,19 +38,19 @@ DEFAULT_MODEL_ID = "openai:gpt-5.4-mini"
 
 MODELS = [
     {
-        "id": "anthropic:claude-sonnet-4-5",
-        "name": "Claude Sonnet 4.5",
-        "desc": "Balanced reasoning & speed",
+        "id": "anthropic:claude-haiku-4-5",
+        "name": "Claude Haiku 4.5",
+        "desc": "Anthropic",
     },
     {
         "id": DEFAULT_MODEL_ID,
         "name": "GPT-5.4 mini",
-        "desc": "OpenAI flagship, fast & grounded",
+        "desc": "OpenAI",
     },
     {
-        "id": "google-gla:gemini-2.5-pro",
-        "name": "Gemini 2.5 Pro",
-        "desc": "Long-context reasoning",
+        "id": "google:gemini-3.5-flash",
+        "name": "Gemini 3.5 Flash",
+        "desc": "Google",
     },
 ]
 

--- a/frontend/dash_app/config.py
+++ b/frontend/dash_app/config.py
@@ -25,7 +25,7 @@ EXAMPLE_PROMPTS = [
     "Compare the Monroe and Truman doctrines.",
 ]
 
-COMPOSER_PLACEHOLDER = "Ask a queestion…"
+COMPOSER_PLACEHOLDER = "Ask a question…"
 LOADING_TEXT = "Searching the archive"
 ABSTAIN_TEXT = "No grounded sources matched this question."
 ERROR_TEXT = (
@@ -97,7 +97,7 @@ def sources_chip_label(selected_ids: list[str]) -> str:
 # --- Element ids -------------------------------------------------------------
 class ID:
     # stores
-    CONVERSATION = "conv-store"  # active conversation id
+    CHAT = "chat-store"  # active chat id
     MODEL = "model-store"  # selected model id
     SOURCES = "sources-store"  # selected source collection ids
     PENDING = "pending-store"  # in-flight query (drives the agent run)

--- a/frontend/dash_app/main.py
+++ b/frontend/dash_app/main.py
@@ -55,7 +55,7 @@ server = app.server  # for WSGI deployment (e.g. gunicorn)
 
 def _stores() -> list:
     return [
-        dcc.Store(id=ID.CONVERSATION, data=None),
+        dcc.Store(id=ID.CHAT, data=None),
         dcc.Store(id=ID.MODEL, data=DEFAULT_MODEL_ID),
         dcc.Store(id=ID.SOURCES, data=DEFAULT_SOURCE_IDS),
         dcc.Store(id=ID.PENDING, data=None),

--- a/frontend/dash_app/services/chat.py
+++ b/frontend/dash_app/services/chat.py
@@ -1,10 +1,10 @@
-"""Server-side conversation state and the bridge to the agentic RAG loop.
+"""Server-side chat state and the bridge to the agentic RAG loop.
 
-Each browser conversation maps to a :class:`Conversation` holding the Pydantic
+Each browser chat maps to a :class:`Chat` holding the Pydantic
 AI message history and the run's ``AgentDeps`` (which accumulates every chunk
 the agent has seen). Keeping this server-side means the rich, non-JSON state
 — message history and ``RetrievedChunk`` objects — never has to round-trip
-through the browser; the client only carries an opaque conversation id.
+through the browser; the client only carries an opaque chat id.
 
 A new user message launches a fresh agentic loop via ``agent.run_sync``,
 mirroring ``scripts/run_agent.py`` but with the chosen model and prior history.
@@ -87,7 +87,7 @@ class DisplayMessage:
 
 
 @dataclass
-class Conversation:
+class Chat:
     """All state for one chat thread."""
 
     deps: AgentDeps
@@ -100,54 +100,54 @@ class Conversation:
         return self._next_id
 
 
-class ConversationStore:
-    """In-memory registry of conversations, keyed by an opaque id.
+class ChatStore:
+    """In-memory registry of chats, keyed by an opaque id.
 
-    The :class:`RAGClient` is shared across conversations (it only holds HTTP
-    and model clients); each conversation gets its own ``AgentDeps`` so the
+    The :class:`RAGClient` is shared across chats (it only holds HTTP
+    and model clients); each chat gets its own ``AgentDeps`` so the
     accumulated ``seen`` chunks never leak between threads.
     """
 
     def __init__(self) -> None:
         self._client = RAGClient()
-        self._conversations: dict[str, Conversation] = {}
+        self._chats: dict[str, Chat] = {}
         self._lock = threading.Lock()
 
-    def _create(self) -> Conversation:
-        return Conversation(deps=AgentDeps(client=self._client))
+    def _create(self) -> Chat:
+        return Chat(deps=AgentDeps(client=self._client))
 
-    def get(self, conv_id: str) -> Conversation:
-        """Return the conversation for ``conv_id``, creating it if needed."""
+    def get(self, chat_id: str) -> Chat:
+        """Return the chat for ``chat_id``, creating it if needed."""
         with self._lock:
-            conv = self._conversations.get(conv_id)
-            if conv is None:
-                conv = self._create()
-                self._conversations[conv_id] = conv
-            return conv
+            chat = self._chats.get(chat_id)
+            if chat is None:
+                chat = self._create()
+                self._chats[chat_id] = chat
+            return chat
 
-    def has_messages(self, conv_id: str | None) -> bool:
-        """Whether a conversation exists and has any turns (without creating it)."""
-        conv = self._conversations.get(conv_id) if conv_id else None
-        return bool(conv and conv.display)
+    def has_messages(self, chat_id: str | None) -> bool:
+        """Whether a chat exists and has any turns (without creating it)."""
+        chat = self._chats.get(chat_id) if chat_id else None
+        return bool(chat and chat.display)
 
     def is_server_healthy(self) -> bool:
         """Whether the retrieval server is warm and ready to serve requests."""
         return self._client.is_healthy()
 
-    def reset(self, conv_id: str) -> None:
-        """Forget a conversation so the next message starts a clean thread."""
+    def reset(self, chat_id: str) -> None:
+        """Forget a chat so the next message starts a clean thread."""
         with self._lock:
-            self._conversations.pop(conv_id, None)
+            self._chats.pop(chat_id, None)
 
-    def add_user_message(self, conv_id: str, text: str) -> None:
-        conv = self.get(conv_id)
-        conv.display.append(
-            DisplayMessage(id=conv.next_id(), role="user", text=text)
+    def add_user_message(self, chat_id: str, text: str) -> None:
+        chat = self.get(chat_id)
+        chat.display.append(
+            DisplayMessage(id=chat.next_id(), role="user", text=text)
         )
 
     def run_assistant(
         self,
-        conv_id: str,
+        chat_id: str,
         query: str,
         model_id: str,
         sources: list[str],
@@ -157,24 +157,24 @@ class ConversationStore:
         Failures (e.g. a missing provider API key) are caught and surfaced as a
         friendly error message rather than crashing the callback.
         """
-        conv = self.get(conv_id)
-        conv.deps.sources = sources
+        chat = self.get(chat_id)
+        chat.deps.sources = sources
         try:
             result = agent.run_sync(
                 query,
-                deps=conv.deps,
-                message_history=conv.messages,
+                deps=chat.deps,
+                message_history=chat.messages,
                 model=model_id,
                 usage_limits=UsageLimits(request_limit=REQUEST_LIMIT),
             )
-            conv.messages = result.all_messages()
-            answer, chunks = parse_agent_run(result, conv.deps)
+            chat.messages = result.all_messages()
+            answer, chunks = parse_agent_run(result, chat.deps)
             sources = [
                 SourceView.from_chunk(i, c) for i, c in enumerate(chunks, 1)
             ]
-            conv.display.append(
+            chat.display.append(
                 DisplayMessage(
-                    id=conv.next_id(),
+                    id=chat.next_id(),
                     role="assistant",
                     text=answer or ABSTAIN_TEXT,
                     sources=sources,
@@ -182,9 +182,9 @@ class ConversationStore:
                 )
             )
         except Exception:
-            conv.display.append(
+            chat.display.append(
                 DisplayMessage(
-                    id=conv.next_id(),
+                    id=chat.next_id(),
                     role="assistant",
                     text=ERROR_TEXT,
                     error=True,
@@ -193,4 +193,4 @@ class ConversationStore:
 
 
 # A single store instance backs the whole app.
-store = ConversationStore()
+store = ChatStore()


### PR DESCRIPTION
## UI polish for the Dash chat frontend

A round of copy, layout, and naming cleanups across the Dash app (`frontend/dash_app/`).

### Changes

**Rename "conversation" → "chat" throughout**
- Renamed `components/conversation.py` → `components/chat.py` and `services/conversation.py` → `services/chat.py`.
- Renamed the `Conversation`/`ConversationStore` classes to `Chat`/`ChatStore`, the `render_conversation` function to `render_chat`, and the `CONVERSATION` store id to `CHAT` — propagated through callbacks, `main.py`, and the header/dialog copy ("New chat", "Start a new chat?").

**Header: About moved into a filled info icon**
- Replaced the text "ⓘ About" action with a compact filled-accent info circle next to the title, with a working hover state (new `.hover-icon-fill` CSS) and a "How it works" tooltip.
- Bumped the title to 20px and left-aligned the About popover under the icon.

**Copy updates**
- Refreshed the About lead, welcome heading/subtext, and composer placeholder.
- Removed redundant helper text from the sources picker.
- Polished the new-chat confirmation dialog (wider, centered buttons).

**Model registry / config**
- `config.py` no longer imports `MODEL` from `frontend.agent`; it defines a local `DEFAULT_MODEL_ID = "openai:gpt-5.4-mini"`.
- Updated the model choices to Claude Haiku 4.5, GPT-5.4 mini, and Gemini 3.5 Flash, with simplified provider-name descriptions.

### Notes
No behavioral changes to the agent or retrieval loop — these are presentation, naming, and config refactors.