### PR TITLE
Update deploy pipeline for new frontend

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -116,3 +116,5 @@ jobs:
             SERVER_URL=${{ env.SERVER_URL }}
             OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}
             OPENAI_MODEL=${{ env.OPENAI_MODEL }}
+            ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}
+            GEMINI_API_KEY=${{ secrets.GEMINI_API_KEY }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,12 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Expose port 8080 for Cloud Run
 EXPOSE 8080
 
-# Run Streamlit with Cloud Run-compatible settings
-CMD ["streamlit", "run", "frontend/app.py", \
-     "--server.port=8080", \
-     "--server.address=0.0.0.0", \
-     "--server.headless=true", \
-     "--browser.gatherUsageStats=false"]
+# Serve the Dash app via gunicorn. `frontend.dash_app.main:server` is the WSGI
+# callable (Flask) exposed by the Dash app. Requests are I/O-bound on the
+# retrieval server and model providers, so a single worker with several threads
+# handles concurrency well; scale workers/threads to the host's CPU and memory.
+CMD ["gunicorn", "frontend.dash_app.main:server", \
+     "--bind=0.0.0.0:8080", \
+     "--workers=1", \
+     "--threads=8", \
+     "--timeout=120"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ description = ""
 requires-python = ">=3.12"
 dependencies = [
     "dash>=4.3.0",
+    "gunicorn>=23.0.0",
     "httpx>=0.28.1",
     "jinja2>=3.1.6",
     "logfire>=4.37.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1264,6 +1264,18 @@ wheels = [
 ]
 
 [[package]]
+name = "gunicorn"
+version = "26.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/b7/a4a3f632f823e432ce6bc65f62961b7980c898c77f075a2f7118cb3846fe/gunicorn-26.0.0.tar.gz", hash = "sha256:ca9346f85e3a4aeeb64d491045c16b9a35647abd37ea15efe53080eb8b090baf", size = 727286, upload-time = "2026-05-05T06:38:25.529Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/40/9c2384fc2be4ad25dd4a49decd5ad9ea5a3639814c11bd40ab77cb9f0a14/gunicorn-26.0.0-py3-none-any.whl", hash = "sha256:40233d26a5f0d1872916188c276e21641155111c2853f0c2cd55260aec0d24fc", size = 212009, upload-time = "2026-05-05T06:38:23.007Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3186,6 +3198,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "dash" },
+    { name = "gunicorn" },
     { name = "httpx" },
     { name = "jinja2" },
     { name = "logfire" },
@@ -3222,6 +3235,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "dash", specifier = ">=4.3.0" },
+    { name = "gunicorn", specifier = ">=23.0.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "logfire", specifier = ">=4.37.0" },


### PR DESCRIPTION
## Switch deployment pipeline from Streamlit to Dash

### What & why
The frontend is now an agentic RAG app built with Dash (`frontend/dash_app/`), but the deployment pipeline still shipped the legacy one-shot Streamlit app. This updates the Docker image and Cloud Run deploy to serve the Dash app instead.

### Changes
- **Dockerfile** — replace the Streamlit `CMD` with **gunicorn** serving the Dash WSGI callable (`frontend.dash_app.main:server`) on `0.0.0.0:8080`.
- **pyproject.toml / uv.lock** — add `gunicorn` so it flows into the CI-generated `requirements.txt`.
- **build-and-deploy.yml** — pass `ANTHROPIC_API_KEY` and `GEMINI_API_KEY` to Cloud Run so the Dash model picker's Claude/Gemini options work alongside OpenAI.

### Required before merge/deploy
Add `ANTHROPIC_API_KEY` and `GEMINI_API_KEY` to the repo's **Actions secrets** — otherwise those models fail at runtime (OpenAI still works).

### Scope / follow-up
This intentionally keeps the legacy code in place (`frontend/app.py`, the `streamlit` dependency, the import-time `OPENAI_MODEL` coupling in `frontend/client.py`). A follow-up PR will remove that cruft **after** the new app is deployed and verified.
