### PR TITLE
Fix Cloud Run startup crash from logfire token

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -117,4 +117,6 @@ jobs:
             OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}
             OPENAI_MODEL=${{ env.OPENAI_MODEL }}
             ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}
-            GEMINI_API_KEY=${{ secrets.GEMINI_API_KEY }}
+            GOOGLE_API_KEY=${{ secrets.GOOGLE_API_KEY }}
+            LOGFIRE_TOKEN=${{ secrets.LOGFIRE_TOKEN }}
+            LOGFIRE_ENV=prod

--- a/frontend/dash_app/main.py
+++ b/frontend/dash_app/main.py
@@ -7,7 +7,7 @@ Run locally with::
 The agent talks to the retrieval server over HTTP (``SERVER_URL``) and to the
 model providers directly, so the usual environment variables must be set (see
 ``.env``): ``OPENAI_API_KEY`` / ``SERVER_URL`` are required, and Claude/Gemini
-in the model picker additionally need ``ANTHROPIC_API_KEY`` / ``GEMINI_API_KEY``.
+in the model picker additionally need ``ANTHROPIC_API_KEY`` / ``GOOGLE_API_KEY``.
 """
 
 import os
@@ -35,6 +35,10 @@ load_dotenv()
 logfire.configure(
     service_name="presidents-rag",
     environment=os.getenv("LOGFIRE_ENV", "dev"),
+    # Send traces only when a write token is configured (LOGFIRE_TOKEN). Without
+    # this, configure() raises at import time when no token is found, which would
+    # crash the app on startup (e.g. in any environment that lacks the token).
+    send_to_logfire="if-token-present",
 )
 
 FONTS = (


### PR DESCRIPTION
## Fix Cloud Run 503 on startup (logfire token)

### Problem
After switching the deployment to the Dash app, the Cloud Run service returned **503 "Service Unavailable"** — the container crashed on startup. The logs showed `LogfireConfigError` raised from `logfire.configure()` at import time in `frontend/dash_app/main.py`: with no write token present in the container, `configure()` throws, killing the gunicorn worker before it can bind to port 8080.

This only surfaced in Cloud Run because local runs pick up Logfire credentials from `.env`/cached auth; the new Dash entrypoint calls `logfire.configure()` at import time, which the old Streamlit entrypoint never did.

### Fix
- **`main.py`** — pass `send_to_logfire="if-token-present"` so logfire sends traces when a token is configured and silently no-ops otherwise, instead of crashing the app.
- **`build-and-deploy.yml`** — inject `LOGFIRE_TOKEN` (from secrets) and `LOGFIRE_ENV=prod` into the Cloud Run deploy so telemetry flows in production. Also renames the Gemini key env var to `GOOGLE_API_KEY`.

### Required before deploy
Add a Logfire **write token** as the GitHub Actions secret `LOGFIRE_TOKEN`. (If absent, the app now still boots — it just won't emit telemetry.)