### PR TITLE
Retrieval models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ notebooks
 weights
 .cursor/
 text/
+chunks/
 .neon

--- a/backend/server.py
+++ b/backend/server.py
@@ -13,9 +13,9 @@ MODAL_APP_NAME = "presidents-rag"
 MODAL_VOLUME_NAME = "presidents-rag"
 MOUNT_PATH = "/data"
 
-VECTOR_STORE_CONFIG_ID = 3
+VECTOR_STORE_CONFIG_ID = 1
 SENTENCE_TRANSFORMER_PATH = "weights/sentence-transformers_all-MiniLM-L6-v2"
-CROSS_ENCODER_PATH = "weights/cross-encoder_ms-marco-MiniLM-L-6-v2"
+CROSS_ENCODER_PATH = "weights/cross-encoder_ms-marco-MiniLM-L6-v2"
 
 # The runtime queries Postgres through the pooled connection. The value is read
 # from the deploy environment (GitHub secrets in CI, .env locally) and injected

--- a/backend/server.py
+++ b/backend/server.py
@@ -11,12 +11,11 @@ import modal
 
 MODAL_APP_NAME = "presidents-rag"
 MODAL_VOLUME_NAME = "presidents-rag"
+MOUNT_PATH = "/data"
 
-SENTENCE_TRANSFORMER_PATH = (
-    "/data/weights/sentence-transformers_all-MiniLM-L6-v2"
-)
-CROSS_ENCODER_PATH = "/data/weights/cross-encoder_ms-marco-MiniLM-L-6-v2"
 VECTOR_STORE_CONFIG_ID = 3
+SENTENCE_TRANSFORMER_PATH = "weights/sentence-transformers_all-MiniLM-L6-v2"
+CROSS_ENCODER_PATH = "weights/cross-encoder_ms-marco-MiniLM-L-6-v2"
 
 # The runtime queries Postgres through the pooled connection. The value is read
 # from the deploy environment (GitHub secrets in CI, .env locally) and injected
@@ -45,7 +44,7 @@ volume = modal.Volume.from_name(MODAL_VOLUME_NAME)
 
 @app.cls(
     image=image,
-    volumes={"/data": volume},
+    volumes={MOUNT_PATH: volume},
     secrets=[db_secret],
     gpu="T4",
     scaledown_window=600,
@@ -58,8 +57,12 @@ class Server:
     def load_models(self):
         from sentence_transformers import CrossEncoder, SentenceTransformer
 
-        self.embedder = SentenceTransformer(SENTENCE_TRANSFORMER_PATH)
-        self.cross_encoder = CrossEncoder(CROSS_ENCODER_PATH)
+        embedder_path = os.path.join(MOUNT_PATH, SENTENCE_TRANSFORMER_PATH)
+        cross_encoder_path = os.path.join(MOUNT_PATH, CROSS_ENCODER_PATH)
+        print(f"Loading embedder from: {embedder_path}")
+        print(f"Loading cross-encoder from: {cross_encoder_path}")
+        self.embedder = SentenceTransformer(embedder_path)
+        self.cross_encoder = CrossEncoder(cross_encoder_path)
 
     @modal.asgi_app()
     def fastapi_server(self):

--- a/scripts/download_weights.py
+++ b/scripts/download_weights.py
@@ -3,6 +3,12 @@ Download sentence-transformers model weights to local directory.
 
 This script downloads model weights and saves them to the weights/ directory
 in a subfolder named after the model.
+
+Examples:
+    python scripts/download_weights.py BAAI/bge-base-en-v1.5
+    python scripts/download_weights.py sentence-transformers/all-MiniLM-L6-v2
+    python scripts/download_weights.py BAAI/bge-reranker-base -ce
+    python scripts/download_weights.py cross-encoder/ms-marco-MiniLM-L-6-v2 --cross-encoder
 """
 
 import argparse
@@ -11,27 +17,20 @@ import os
 from sentence_transformers import CrossEncoder, SentenceTransformer
 
 
-def download_weights(model_name: str):
+def download_weights(model_name: str, *, cross_encoder: bool = False):
     """Download model weights to weights/{model_name}/ directory.
 
     Args:
-        model_name: Full model name (e.g., "sentence-transformers/all-MiniLM-L6-v2" or "cross-encoder/ms-marco-MiniLM-L-6-v2)
+        model_name: Hugging Face model ID (e.g., "BAAI/bge-base-en-v1.5").
+        cross_encoder: If True, load with CrossEncoder; otherwise SentenceTransformer.
     """
-    # Extract model name for folder
     folder_name = model_name.replace("/", "_")
     weights_dir = os.path.join("weights", folder_name)
-
-    # Create weights directory if it doesn't exist
     os.makedirs(weights_dir, exist_ok=True)
-
-    # Download and save the model
     print(f"Downloading {model_name}...")
 
-    # Use appropriate model class based on model type
-    if "cross-encoder" in model_name.lower():
-        model = CrossEncoder(model_name)
-    else:
-        model = SentenceTransformer(model_name)
+    loader = CrossEncoder if cross_encoder else SentenceTransformer
+    model = loader(model_name)
 
     print(f"Saving to {os.path.abspath(weights_dir)}")
     model.save(weights_dir)
@@ -57,7 +56,13 @@ if __name__ == "__main__":
     parser.add_argument(
         "model_name",
         type=str,
-        help='Model name to download (e.g., "sentence-transformers/all-MiniLM-L6-v2")',
+        help='Hugging Face model ID (e.g., "BAAI/bge-base-en-v1.5")',
+    )
+    parser.add_argument(
+        "--cross-encoder",
+        "-ce",
+        action="store_true",
+        help="Load as a cross-encoder (reranker) instead of a bi-encoder embedder",
     )
     args = parser.parse_args()
-    download_weights(args.model_name)
+    download_weights(args.model_name, cross_encoder=args.cross_encoder)

--- a/scripts/ingest.py
+++ b/scripts/ingest.py
@@ -31,8 +31,8 @@ class ChunkRecord:
 
 
 MODELS = {
-    "BAAI/bge-small-en-v1.5": EmbeddingModelConfig(
-        weights_path="weights/BAAI_bge-small-en-v1.5",
+    "sentence-transformers/all-MiniLM-L6-v2": EmbeddingModelConfig(
+        weights_path="weights/sentence-transformers_all-MiniLM-L6-v2",
         data_model=ChunkDim384,
         dim=384,
     ),
@@ -41,8 +41,8 @@ MODELS = {
         data_model=ChunkDim384,
         dim=384,
     ),
-    "sentence-transformers/all-MiniLM-L6-v2": EmbeddingModelConfig(
-        weights_path="weights/sentence-transformers_all-MiniLM-L6-v2",
+    "BAAI/bge-small-en-v1.5": EmbeddingModelConfig(
+        weights_path="weights/BAAI_bge-small-en-v1.5",
         data_model=ChunkDim384,
         dim=384,
     ),

--- a/scripts/ingest.py
+++ b/scripts/ingest.py
@@ -1,8 +1,9 @@
 """Chunk documents, embed them, and load into the vector store database."""
 
 import argparse
+import json
 import time
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from pathlib import Path
 
 from dotenv import load_dotenv
@@ -77,6 +78,23 @@ def chunk_txt_files(
                 )
             )
     return chunks
+
+
+def save_chunks(
+    chunks: list[ChunkRecord],
+    chunk_size: int,
+    chunk_overlap: int,
+) -> Path:
+    out_dir = PROJECT_ROOT / "chunks"
+    out_dir.mkdir(exist_ok=True)
+    path = out_dir / f"chunks_cs{chunk_size}_co{chunk_overlap}.json"
+    path.write_text(
+        json.dumps(
+            [asdict(chunk) for chunk in chunks], indent=2, ensure_ascii=False
+        ),
+        encoding="utf-8",
+    )
+    return path
 
 
 def ingest(
@@ -175,6 +193,12 @@ def main() -> None:
         default=64,
         help="Batch size for embedding chunks.",
     )
+    parser.add_argument(
+        "-s",
+        "--save-chunks",
+        action="store_true",
+        help="Save all chunks to a local JSON file before ingesting.",
+    )
     args = parser.parse_args()
 
     if args.model not in MODELS:
@@ -199,6 +223,10 @@ def main() -> None:
             f"Chunked {len(source_chunks)} chunks from {source!r} "
             f"({documents_folder})"
         )
+
+    if args.save_chunks:
+        path = save_chunks(chunks, args.chunk_size, args.chunk_overlap)
+        print(f"Saved {len(chunks)} chunks to {path}")
 
     num_chunks = ingest(
         chunks=chunks,

--- a/scripts/ingest.py
+++ b/scripts/ingest.py
@@ -30,6 +30,16 @@ class ChunkRecord:
 
 
 MODELS = {
+    "BAAI/bge-small-en-v1.5": EmbeddingModelConfig(
+        weights_path="weights/BAAI_bge-small-en-v1.5",
+        data_model=ChunkDim384,
+        dim=384,
+    ),
+    "sentence-transformers/all-MiniLM-L12-v2": EmbeddingModelConfig(
+        weights_path="weights/sentence-transformers_all-MiniLM-L12-v2",
+        data_model=ChunkDim384,
+        dim=384,
+    ),
     "sentence-transformers/all-MiniLM-L6-v2": EmbeddingModelConfig(
         weights_path="weights/sentence-transformers_all-MiniLM-L6-v2",
         data_model=ChunkDim384,


### PR DESCRIPTION
## Summary

Expands the ingest pipeline to support additional embedding models and optionally export chunks to local JSON for inspection, with small supporting changes to weight download and Modal model loading.

### Ingest (`scripts/ingest.py`)

- **New embedding models:** `sentence-transformers/all-MiniLM-L12-v2` and `BAAI/bge-small-en-v1.5` (both 384-dim, same `ChunkDim384` table).
- **`--save-chunks` / `-s` flag:** When set, writes all chunks to `chunks/chunks_cs{chunk_size}_co{chunk_overlap}.json` before embedding and DB ingest. Output is a flat JSON array of `{source, document, start_index, text}` objects — filename encodes chunk params only, since chunking is model-independent. Ingest proceeds normally either way.

### Other changes

- **`scripts/download_weights.py`:** Replaces fragile name-based cross-encoder detection with an explicit `--cross-encoder` / `-ce` flag, so any Hugging Face bi-encoder or reranker ID can be downloaded reliably.
- **`backend/server.py`:** Centralizes Modal volume mount path (`MOUNT_PATH`) and joins it with relative weight paths at load time; updates `VECTOR_STORE_CONFIG_ID`.
- **`.gitignore`:** Ignores generated `chunks/` output.

## Test plan

- [ ] Download weights for a new model: `python scripts/download_weights.py BAAI/bge-small-en-v1.5`
- [ ] Ingest with chunk export: `python scripts/ingest.py -m BAAI/bge-small-en-v1.5 -cs 900 -co 300 -s`
- [ ] Verify `chunks/chunks_cs900_co300.json` contains expected chunk records
- [ ] Confirm ingest completes and chunks land in the vector store
- [ ] Download a reranker with explicit flag: `python scripts/download_weights.py BAAI/bge-reranker-base -ce`
- [ ] Deploy/restart Modal server and confirm models load from volume paths correctly