### PR TITLE
Update evals

### DIFF
--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -2,6 +2,8 @@
 
 from pydantic import BaseModel
 
+CHUNK_KEY_DELIMITER = "$"
+
 
 class RetrievedChunk(BaseModel):
     """A single document chunk returned by retrieval/reranking.
@@ -18,6 +20,18 @@ class RetrievedChunk(BaseModel):
     retrieval_score: float | None = None
     rerank_score: float | None = None
     chunk_id: int | None = None
+
+
+def chunk_key(chunk: "RetrievedChunk") -> str:
+    """Stable, embedding-model-independent identifier for a logical chunk.
+
+    Joins the ``(source, document, start_index)`` identity with
+    ``CHUNK_KEY_DELIMITER`` so eval gold labels remain valid across embedding
+    models, whose DB primary keys differ for the same logical chunk.
+    """
+    return CHUNK_KEY_DELIMITER.join(
+        [chunk.source, chunk.document, str(chunk.start_index)]
+    )
 
 
 class RetrieveRequest(BaseModel):

--- a/evals/datasets/dataset_generation.py
+++ b/evals/datasets/dataset_generation.py
@@ -6,8 +6,11 @@ from pydantic_evals import Case, Dataset
 from evals.evaluators import Correctness, Faithfulness, Relevance
 from evals.schemas import GenerationResult
 
-JUDGE_MODEL = "openai:gpt-5.4"
-JUDGE_MODEL_SETTINGS = ModelSettings(temperature=0)
+JUDGE_MODEL = "openai:gpt-5.4-mini"
+JUDGE_MODEL_SETTINGS = ModelSettings(
+    temperature=0,
+    thinking="high",
+)
 
 CASES_SINGLEHOP = [
     Case(

--- a/evals/datasets/dataset_generation.py
+++ b/evals/datasets/dataset_generation.py
@@ -104,8 +104,3 @@ generation_dataset = Dataset[str, GenerationResult](
         Faithfulness(model=JUDGE_MODEL, model_settings=JUDGE_MODEL_SETTINGS),
     ],
 )
-
-# TODO: Add efficiency metrics
-# TODO: Add an evaluator that measures the number of tool calls made
-# TODO: Add an evaluator that measures the number of tokens used / cost
-# TODO: Add an evaluator that measures latency

--- a/evals/datasets/dataset_generation.py
+++ b/evals/datasets/dataset_generation.py
@@ -6,23 +6,98 @@ from pydantic_evals import Case, Dataset
 from evals.evaluators import Correctness, Faithfulness, Relevance
 from evals.schemas import GenerationResult
 
+# TODO: Use a stronger model for evaluation (e.g. gpt-5.4)
 JUDGE_MODEL = "openai:gpt-5.4-mini"
 JUDGE_MODEL_SETTINGS = ModelSettings(temperature=0)
 
+CASES_SINGLEHOP = [
+    Case(
+        name="singlehop_01",
+        inputs="Who did Lincoln promote after learning he had no presidential ambitions?",
+        expected_output="Lincoln promoted Ulysses S. Grant.",
+    ),
+    Case(
+        name="singlehop_02",
+        inputs="How did Andrew Jackson's wife die?",
+        expected_output="Rachel Jackson died of either a stroke or a heart attack.",
+    ),
+    Case(
+        name="singlehop_03",
+        inputs="How did Nixon pay for law school?",
+        expected_output="Nixon received a scholarship from the Duke University School of Law.",
+    ),
+    Case(
+        name="singlehop_04",
+        inputs="How did Kennedy prepare for his inaugural address?",
+        expected_output="Kennedy carefully studied famous American speeches, such as the Gettysburg Address, and copied their terse, vivid style.",
+    ),
+    Case(
+        name="singlehop_05",
+        inputs="How did Gerald Ford signal his openness to running with Reagan on the 1980 presidential ticket?",
+        expected_output="Ford discussed the idea of running with Reagan on the 1980 ticket during an interview with Walter Cronkite.",
+    ),
+]
+
+CASES_MULTIHOP = [
+    Case(
+        name="multihop_01",
+        inputs="On what date was the president that Mark Twain helped via a generous book deal born?",
+        expected_output="April 27, 1822",
+    ),
+    Case(
+        name="multihop_02",
+        inputs="What physical activities were typically included in the routine (while he was in office) of the president who ordered the atomic bombing of Japan?",
+        expected_output="While in the White House, Truman's routine included a one or two mile walk and swimming laps in the White House pool.",
+    ),
+    Case(
+        name="multihop_03",
+        inputs="Which presidents have been governor of the state where Nixon was born?",
+        expected_output="Ronald Reagan",
+    ),
+    Case(
+        name="multihop_04",
+        inputs="On which dates did the presidents who graduated from Princeton University die?",
+        expected_output="James Madison died on June 28, 1836, and Woodrow Wilson died on February 3, 1924.",
+    ),
+    Case(
+        name="multihop_05",
+        inputs="Who was the last president born in Ohio?",
+        expected_output="Warren G. Harding was the last president born in Ohio.",
+    ),
+]
+
+CASES_UNANSWERABLE = [
+    Case(
+        name="unanswerable_01",
+        inputs="How old was Millard Fillmore when he said his first words?",
+        expected_output="The knowledge base does not contain information about Millard Fillmore's first words.",
+    ),
+    Case(
+        name="unanswerable_02",
+        inputs="What was the name of George W. Bush's first dog?",
+        expected_output="The knowledge base does not contain information about George W. Bush's first dog.",
+    ),
+    Case(
+        name="unanswerable_03",
+        inputs="What was Zachary Taylor's favorite food as a teenager?",
+        expected_output="The knowledge base does not contain information about Zachary Taylor's favorite food as a teenager.",
+    ),
+    Case(
+        name="unanswerable_04",
+        inputs="What was Jimmy Carter's view of the Boston Red Sox?",
+        expected_output="The knowledge base does not contain information about Jimmy Carter's view of the Boston Red Sox.",
+    ),
+    Case(
+        name="unanswerable_05",
+        inputs="Which novel did Taft read most during his college years?",
+        expected_output="The knowledge base does not contain information about which novel Taft read most during his college years.",
+    ),
+]
+
+
 generation_dataset = Dataset[str, GenerationResult](
     name="generation",
-    cases=[
-        Case(
-            name="case_01",
-            inputs="Who did Lincoln promote after learning he had no presidential ambitions?",
-            expected_output="Lincoln promoted Ulysses S. Grant.",
-        ),
-        Case(
-            name="case_02",
-            inputs="How did Andrew Jackson's wife die?",
-            expected_output="Rachel Jackson died of a stroke or heart attack.",
-        ),
-    ],
+    cases=CASES_SINGLEHOP + CASES_MULTIHOP + CASES_UNANSWERABLE,
     evaluators=[
         Relevance(model=JUDGE_MODEL, model_settings=JUDGE_MODEL_SETTINGS),
         Correctness(model=JUDGE_MODEL, model_settings=JUDGE_MODEL_SETTINGS),
@@ -30,4 +105,7 @@ generation_dataset = Dataset[str, GenerationResult](
     ],
 )
 
-# TODO: Expand this stubbed dataset with more cases.
+# TODO: Add efficiency metrics
+# TODO: Add an evaluator that measures the number of tool calls made
+# TODO: Add an evaluator that measures the number of tokens used / cost
+# TODO: Add an evaluator that measures latency

--- a/evals/datasets/dataset_generation.py
+++ b/evals/datasets/dataset_generation.py
@@ -6,8 +6,7 @@ from pydantic_evals import Case, Dataset
 from evals.evaluators import Correctness, Faithfulness, Relevance
 from evals.schemas import GenerationResult
 
-# TODO: Use a stronger model for evaluation (e.g. gpt-5.4)
-JUDGE_MODEL = "openai:gpt-5.4-mini"
+JUDGE_MODEL = "openai:gpt-5.4"
 JUDGE_MODEL_SETTINGS = ModelSettings(temperature=0)
 
 CASES_SINGLEHOP = [

--- a/evals/datasets/dataset_retrieval.py
+++ b/evals/datasets/dataset_retrieval.py
@@ -137,6 +137,32 @@ CASES_LEXICAL = [
             "miller_center$40_ronald_reagan_4_foreign-affairs.txt$16349",
         ],
     ),
+    Case(
+        name="lexical_08",
+        inputs="Who wrote 'Maine and her soil, or BLOOD!'?",
+        expected_output=[
+            "wikipedia$martin_van_buren.txt$41446",
+        ],
+    ),
+    Case(
+        name="lexical_09",
+        inputs="Who believed the ghost of assassinated president William McKinley had directed him to kill Roosevelt?",
+        expected_output=[
+            "wikipedia$theodore_roosevelt.txt$69119",
+        ],
+    ),
+    Case(
+        name="lexical_10",
+        inputs="Which president had a brother Vivian and sister Mary Jane?",
+        expected_output=[
+            "miller_center$33_harry_s_truman_1_life-before-the-presidency.txt$0",
+            "miller_center$33_harry_s_truman_1_life-before-the-presidency.txt$2028",
+            "miller_center$33_harry_s_truman_6_family-life.txt$727",
+            "wikipedia$harry_s_truman.txt$35",
+            "wikipedia$harry_s_truman.txt$2451",
+            "wikipedia$harry_s_truman.txt$12339",
+        ],
+    ),
 ]
 
 

--- a/evals/datasets/dataset_retrieval.py
+++ b/evals/datasets/dataset_retrieval.py
@@ -5,7 +5,7 @@ from pydantic_evals import Case, Dataset
 from evals.evaluators import HitAtK, PrecisionAtK, RecallAtK
 
 # Each case's `inputs` is a short, search-engine-style query: the string used for
-# both vector retrieval and reranking during evals. `metadata["full_Q"]` preserves
+# both vector retrieval and reranking during evals. `metadata["full_question"]` preserves
 # the original natural-language question that case was written to answer.
 #
 # We evaluate on rephrased queries rather than full questions because that mirrors
@@ -21,7 +21,7 @@ CASES_SEMANTIC = [
         name="semantic_01",
         inputs="lincoln who promoted no presidential ambitions",
         metadata={
-            "full_Q": "Who did Lincoln promote after learning he had no presidential ambitions?"
+            "full_question": "Who did Lincoln promote after learning he had no presidential ambitions?"
         },
         expected_output=[
             "wikipedia$abraham_lincoln.txt$55825",
@@ -30,7 +30,7 @@ CASES_SEMANTIC = [
     Case(
         name="semantic_02",
         inputs="andrew jackson wife death",
-        metadata={"full_Q": "How did Andrew Jackson's wife die?"},
+        metadata={"full_question": "How did Andrew Jackson's wife die?"},
         expected_output=[
             "wikipedia$andrew_jackson.txt$28233",
         ],
@@ -39,7 +39,7 @@ CASES_SEMANTIC = [
         name="semantic_03",
         inputs="president wife died rumors cheating previous husband",
         metadata={
-            "full_Q": "Which president was married to a woman whose death was potentially caused by rumors that she cheated on her previous husband?"
+            "full_question": "Which president was married to a woman whose death was potentially caused by rumors that she cheated on her previous husband?"
         },
         expected_output=[
             "wikipedia$andrew_jackson.txt$28233",
@@ -49,7 +49,7 @@ CASES_SEMANTIC = [
         name="semantic_04",
         inputs="19th century president cabinet all resigned sequentially",
         metadata={
-            "full_Q": "Who was almost ousted from the presidency in the middle of the nineteenth century due to his cabinet members all quitting in a staged, organized manner?"
+            "full_question": "Who was almost ousted from the presidency in the middle of the nineteenth century due to his cabinet members all quitting in a staged, organized manner?"
         },
         expected_output=[
             "wikipedia$john_tyler.txt$38479",
@@ -59,7 +59,7 @@ CASES_SEMANTIC = [
         name="semantic_05",
         inputs="president terminal illness second term reelection",
         metadata={
-            "full_Q": "Who did not actively (but perhaps did passively) seek a 2nd term because he knew he had a terminal illness?"
+            "full_question": "Who did not actively (but perhaps did passively) seek a 2nd term because he knew he had a terminal illness?"
         },
         expected_output=[
             "miller_center$21_chester_a_arthur_5_life-after-the-presidency.txt$0",
@@ -70,7 +70,7 @@ CASES_SEMANTIC = [
         name="semantic_06",
         inputs="military force china save diplomats rebels killed christians",
         metadata={
-            "full_Q": "Who sent a military force to China to save diplomats from a violent group of rebels who had killed Christians?"
+            "full_question": "Who sent a military force to China to save diplomats from a violent group of rebels who had killed Christians?"
         },
         expected_output=[
             "miller_center$25_william_mckinley_4_foreign-affairs.txt$8642",
@@ -82,7 +82,7 @@ CASES_SEMANTIC = [
         name="semantic_07",
         inputs="ussr commercial jet east asia 300 civilians killed",
         metadata={
-            "full_Q": "Which action taken by the USSR regarding a commercial jet from an east asian nation resulted in the deaths of nearly three hundred civilians?"
+            "full_question": "Which action taken by the USSR regarding a commercial jet from an east asian nation resulted in the deaths of nearly three hundred civilians?"
         },
         expected_output=[
             "miller_center$40_ronald_reagan_4_foreign-affairs.txt$11546",
@@ -92,7 +92,7 @@ CASES_SEMANTIC = [
         name="semantic_08",
         inputs="john adams act signed anti-french foreign controversy",
         metadata={
-            "full_Q": "What was the act that Adams signed into law whose passage was facilitated by anti-French feelings after a foreign controversy?"
+            "full_question": "What was the act that Adams signed into law whose passage was facilitated by anti-French feelings after a foreign controversy?"
         },
         expected_output=[
             "miller_center$02_john_adams_3_domestic-affairs.txt$505",
@@ -103,7 +103,7 @@ CASES_SEMANTIC = [
         name="semantic_09",
         inputs="president native american citizenship inaugural address",
         metadata={
-            "full_Q": "Who advocated for the citizenship of native americans during his inaugural address?"
+            "full_question": "Who advocated for the citizenship of native americans during his inaugural address?"
         },
         expected_output=[
             "miller_center$18_ulysses_s_grant_3_domestic-affairs.txt$8749",
@@ -114,7 +114,7 @@ CASES_SEMANTIC = [
         name="semantic_10",
         inputs="president elitist son europe royalty",
         metadata={
-            "full_Q": "Which president was accused of being elitist due to his son traveling to Europe and meeting with royalty?"
+            "full_question": "Which president was accused of being elitist due to his son traveling to Europe and meeting with royalty?"
         },
         expected_output=[
             "miller_center$08_martin_van_buren_6_family-life.txt$747",
@@ -128,7 +128,7 @@ CASES_LEXICAL = [
         name="lexical_01",
         inputs="president plymouth elementary school",
         metadata={
-            "full_Q": "Which president went to Plymouth elementary school?"
+            "full_question": "Which president went to Plymouth elementary school?"
         },
         expected_output=[
             "miller_center$30_calvin_coolidge_1_life-before-the-presidency.txt$392",
@@ -137,7 +137,9 @@ CASES_LEXICAL = [
     Case(
         name="lexical_02",
         inputs="kellogg-briand pact signed president",
-        metadata={"full_Q": "Which president signed the Kellogg-Briand Pact?"},
+        metadata={
+            "full_question": "Which president signed the Kellogg-Briand Pact?"
+        },
         expected_output=[
             "miller_center$30_calvin_coolidge_4_foreign-affairs.txt$1062",
             "miller_center$30_calvin_coolidge_0_life-in-brief.txt$4045",
@@ -148,7 +150,7 @@ CASES_LEXICAL = [
         name="lexical_03",
         inputs="forced resign september 11 1841",
         metadata={
-            "full_Q": "Who was almost forced to resign on September 11, 1841?"
+            "full_question": "Who was almost forced to resign on September 11, 1841?"
         },
         expected_output=[
             "wikipedia$john_tyler.txt$38479",
@@ -158,7 +160,7 @@ CASES_LEXICAL = [
         name="lexical_04",
         inputs="mark twain andrew carnegie organization opposed overseas territorial expansion",
         metadata={
-            "full_Q": "Which organization that opposed overseas territorial expansion of the United States did Mark Twain and Andrew Carnegie belong to?"
+            "full_question": "Which organization that opposed overseas territorial expansion of the United States did Mark Twain and Andrew Carnegie belong to?"
         },
         expected_output=[
             "miller_center$25_william_mckinley_4_foreign-affairs.txt$1042",
@@ -169,7 +171,7 @@ CASES_LEXICAL = [
         name="lexical_05",
         inputs="surface mining control and reclamation act signed",
         metadata={
-            "full_Q": "Who signed the Surface Mining Control and Reclamation Act?"
+            "full_question": "Who signed the Surface Mining Control and Reclamation Act?"
         },
         expected_output=[
             "miller_center$39_jimmy_carter_3_domestic-affairs.txt$4322",
@@ -179,7 +181,7 @@ CASES_LEXICAL = [
         name="lexical_06",
         inputs="jefferson letter september 23 1800",
         metadata={
-            "full_Q": "Who did Jefferson write a letter to on September 23, 1800?"
+            "full_question": "Who did Jefferson write a letter to on September 23, 1800?"
         },
         expected_output=[
             "wikipedia$thomas_jefferson.txt$97469",
@@ -189,7 +191,7 @@ CASES_LEXICAL = [
         name="lexical_07",
         inputs="organization eastern caribbean states ask reagan",
         metadata={
-            "full_Q": "What did the Organization of Eastern Caribbean States ask Reagan to do?"
+            "full_question": "What did the Organization of Eastern Caribbean States ask Reagan to do?"
         },
         expected_output=[
             "miller_center$40_ronald_reagan_4_foreign-affairs.txt$15751",
@@ -199,7 +201,9 @@ CASES_LEXICAL = [
     Case(
         name="lexical_08",
         inputs="maine and her soil or blood who wrote",
-        metadata={"full_Q": "Who wrote 'Maine and her soil, or BLOOD!'?"},
+        metadata={
+            "full_question": "Who wrote 'Maine and her soil, or BLOOD!'?"
+        },
         expected_output=[
             "wikipedia$martin_van_buren.txt$41446",
         ],
@@ -208,7 +212,7 @@ CASES_LEXICAL = [
         name="lexical_09",
         inputs="ghost william mckinley directed kill roosevelt",
         metadata={
-            "full_Q": "Who believed the ghost of assassinated president William McKinley had directed him to kill Roosevelt?"
+            "full_question": "Who believed the ghost of assassinated president William McKinley had directed him to kill Roosevelt?"
         },
         expected_output=[
             "wikipedia$theodore_roosevelt.txt$69119",
@@ -218,7 +222,7 @@ CASES_LEXICAL = [
         name="lexical_10",
         inputs="president brother vivian sister mary jane",
         metadata={
-            "full_Q": "Which president had a brother Vivian and sister Mary Jane?"
+            "full_question": "Which president had a brother Vivian and sister Mary Jane?"
         },
         expected_output=[
             "miller_center$33_harry_s_truman_1_life-before-the-presidency.txt$0",

--- a/evals/datasets/dataset_retrieval.py
+++ b/evals/datasets/dataset_retrieval.py
@@ -4,29 +4,156 @@ from pydantic_evals import Case, Dataset
 
 from evals.evaluators import HitAtK, PrecisionAtK, RecallAtK
 
+CASES_SEMANTIC = [
+    Case(
+        name="semantic_01",
+        inputs="Who did Lincoln promote after learning he had no presidential ambitions?",
+        expected_output=[
+            "wikipedia$abraham_lincoln.txt$55825",
+        ],
+    ),
+    Case(
+        name="semantic_02",
+        inputs="How did Andrew Jackson's wife die?",
+        expected_output=[
+            "wikipedia$andrew_jackson.txt$28233",
+        ],
+    ),
+    Case(
+        name="semantic_03",
+        inputs="Which president was married to a woman whose death was potentially caused by rumors that she cheated on her previous husband?",
+        expected_output=[
+            "wikipedia$andrew_jackson.txt$28233",
+        ],
+    ),
+    Case(
+        name="semantic_04",
+        inputs="Who was almost ousted from the presidency in the middle of the nineteenth century due to his cabinet members all quitting in a staged, organized manner?",
+        expected_output=[
+            "wikipedia$john_tyler.txt$38479",
+        ],
+    ),
+    Case(
+        name="semantic_05",
+        inputs="Who did not actively (but perhaps did passively) seek a 2nd term because he knew he had a terminal illness?",
+        expected_output=[
+            "miller_center$21_chester_a_arthur_5_life-after-the-presidency.txt$0",
+            "miller_center$21_chester_a_arthur_2_campaigns-and-elections.txt$3476",
+        ],
+    ),
+    Case(
+        name="semantic_06",
+        inputs="Who sent a military force to China to save diplomats from a violent group of rebels who had killed Christians?",
+        expected_output=[
+            "miller_center$25_william_mckinley_4_foreign-affairs.txt$8642",
+            "miller_center$25_william_mckinley_0_life-in-brief.txt$3081",
+            "wikipedia$william_mckinley.txt$49967",
+        ],
+    ),
+    Case(
+        name="semantic_07",
+        inputs="Which action taken by the USSR regarding a commercial jet from an east asian nation resulted in the deaths of nearly three hundred civilians?",
+        expected_output=[
+            "miller_center$40_ronald_reagan_4_foreign-affairs.txt$11546",
+        ],
+    ),
+    Case(
+        name="semantic_08",
+        inputs="What was the act that Adams signed into law whose passage was facilitated by anti-French feelings after a foreign controversy?",
+        expected_output=[
+            "miller_center$02_john_adams_3_domestic-affairs.txt$505",
+            "wikipedia$john_adams.txt$51038",
+        ],
+    ),
+    Case(
+        name="semantic_09",
+        inputs="Who advocated for the citizenship of native americans during his inaugural address?",
+        expected_output=[
+            "miller_center$18_ulysses_s_grant_3_domestic-affairs.txt$8749",
+            "wikipedia$ulysses_s_grant.txt$45911",
+        ],
+    ),
+    Case(
+        name="semantic_10",
+        inputs="Which president was accused of being elitist due to his son traveling to Europe and meeting with royalty?",
+        expected_output=[
+            "miller_center$08_martin_van_buren_6_family-life.txt$747",
+        ],
+    ),
+]
+
+
+CASES_LEXICAL = [
+    Case(
+        name="lexical_01",
+        inputs="Which president went to Plymouth elementary school?",
+        expected_output=[
+            "miller_center$30_calvin_coolidge_1_life-before-the-presidency.txt$392",
+        ],
+    ),
+    Case(
+        name="lexical_02",
+        inputs="Which president signed the Kellogg-Briand Pact?",
+        expected_output=[
+            "miller_center$30_calvin_coolidge_4_foreign-affairs.txt$1062",
+            "miller_center$30_calvin_coolidge_0_life-in-brief.txt$4045",
+            "miller_center$30_calvin_coolidge_8_impact-and-legacy.txt$720",
+        ],
+    ),
+    Case(
+        name="lexical_03",
+        inputs="Who was almost forced to resign on September 11, 1841?",
+        expected_output=[
+            "wikipedia$john_tyler.txt$38479",
+        ],
+    ),
+    Case(
+        name="lexical_04",
+        inputs="Which organization that opposed overseas territorial expansion of the United States did Mark Twain and Andrew Carnegie belong to?",
+        expected_output=[
+            "miller_center$25_william_mckinley_4_foreign-affairs.txt$1042",
+            "wikipedia$william_jennings_bryan.txt$18241",
+        ],
+    ),
+    Case(
+        name="lexical_05",
+        inputs="Who signed the Surface Mining Control and Reclamation Act?",
+        expected_output=[
+            "miller_center$39_jimmy_carter_3_domestic-affairs.txt$4322",
+        ],
+    ),
+    Case(
+        name="lexical_06",
+        inputs="Who did Jefferson write a letter to on September 23, 1800?",
+        expected_output=[
+            "wikipedia$thomas_jefferson.txt$97469",
+        ],
+    ),
+    Case(
+        name="lexical_07",
+        inputs="What did the Organization of Eastern Caribbean States ask Reagan to do?",
+        expected_output=[
+            "miller_center$40_ronald_reagan_4_foreign-affairs.txt$15751",
+            "miller_center$40_ronald_reagan_4_foreign-affairs.txt$16349",
+        ],
+    ),
+]
+
+
+# A case for generation evals
+# Case(
+#     name="multihop_01",
+#     inputs="On what date was the president that Mark Twain helped via a generous book deal born?",
+#     expected_output="April 27, 1822",
+# ),
+
+
 retrieval_dataset = Dataset[str, list[str]](
     name="retrieval",
-    cases=[
-        Case(
-            name="case_01",
-            inputs="Who did Lincoln promote after learning he had no presidential ambitions?",
-            expected_output=[
-                "wikipedia$abraham_lincoln.txt$55825"
-            ],  # TODO: Verify this output
-        ),
-        Case(
-            name="case_02",
-            inputs="How did Andrew Jackson's wife die?",
-            expected_output=[
-                "wikipedia$andrew_jackson.txt$28233"
-            ],  # TODO: Verify this output
-        ),
-    ],
+    cases=CASES_SEMANTIC + CASES_LEXICAL,
     evaluators=[
         RecallAtK(k=10),
         PrecisionAtK(k=10),
         HitAtK(k=10),
     ],
 )
-
-# TODO: Expand this stubbed dataset with more cases.

--- a/evals/datasets/dataset_retrieval.py
+++ b/evals/datasets/dataset_retrieval.py
@@ -7,40 +7,48 @@ from evals.evaluators import HitAtK, PrecisionAtK, RecallAtK
 CASES_SEMANTIC = [
     Case(
         name="semantic_01",
-        # Who did Lincoln promote after learning he had no presidential ambitions?
         inputs="lincoln who promoted no presidential ambitions",
+        metadata={
+            "full_Q": "Who did Lincoln promote after learning he had no presidential ambitions?"
+        },
         expected_output=[
             "wikipedia$abraham_lincoln.txt$55825",
         ],
     ),
     Case(
         name="semantic_02",
-        # How did Andrew Jackson's wife die?
         inputs="andrew jackson wife death",
+        metadata={"full_Q": "How did Andrew Jackson's wife die?"},
         expected_output=[
             "wikipedia$andrew_jackson.txt$28233",
         ],
     ),
     Case(
         name="semantic_03",
-        # Which president was married to a woman whose death was potentially caused by rumors that she cheated on her previous husband?
         inputs="president wife died rumors cheating previous husband",
+        metadata={
+            "full_Q": "Which president was married to a woman whose death was potentially caused by rumors that she cheated on her previous husband?"
+        },
         expected_output=[
             "wikipedia$andrew_jackson.txt$28233",
         ],
     ),
     Case(
         name="semantic_04",
-        # Who was almost ousted from the presidency in the middle of the nineteenth century due to his cabinet members all quitting in a staged, organized manner?
         inputs="19th century president cabinet all resigned sequentially",
+        metadata={
+            "full_Q": "Who was almost ousted from the presidency in the middle of the nineteenth century due to his cabinet members all quitting in a staged, organized manner?"
+        },
         expected_output=[
             "wikipedia$john_tyler.txt$38479",
         ],
     ),
     Case(
         name="semantic_05",
-        # Who did not actively (but perhaps did passively) seek a 2nd term because he knew he had a terminal illness?
         inputs="president terminal illness second term reelection",
+        metadata={
+            "full_Q": "Who did not actively (but perhaps did passively) seek a 2nd term because he knew he had a terminal illness?"
+        },
         expected_output=[
             "miller_center$21_chester_a_arthur_5_life-after-the-presidency.txt$0",
             "miller_center$21_chester_a_arthur_2_campaigns-and-elections.txt$3476",
@@ -48,8 +56,10 @@ CASES_SEMANTIC = [
     ),
     Case(
         name="semantic_06",
-        # Who sent a military force to China to save diplomats from a violent group of rebels who had killed Christians?
         inputs="military force china save diplomats rebels killed christians",
+        metadata={
+            "full_Q": "Who sent a military force to China to save diplomats from a violent group of rebels who had killed Christians?"
+        },
         expected_output=[
             "miller_center$25_william_mckinley_4_foreign-affairs.txt$8642",
             "miller_center$25_william_mckinley_0_life-in-brief.txt$3081",
@@ -58,16 +68,20 @@ CASES_SEMANTIC = [
     ),
     Case(
         name="semantic_07",
-        # Which action taken by the USSR regarding a commercial jet from an east asian nation resulted in the deaths of nearly three hundred civilians?
         inputs="ussr commercial jet east asia 300 civilians killed",
+        metadata={
+            "full_Q": "Which action taken by the USSR regarding a commercial jet from an east asian nation resulted in the deaths of nearly three hundred civilians?"
+        },
         expected_output=[
             "miller_center$40_ronald_reagan_4_foreign-affairs.txt$11546",
         ],
     ),
     Case(
         name="semantic_08",
-        # What was the act that Adams signed into law whose passage was facilitated by anti-French feelings after a foreign controversy?
         inputs="john adams act signed anti-french foreign controversy",
+        metadata={
+            "full_Q": "What was the act that Adams signed into law whose passage was facilitated by anti-French feelings after a foreign controversy?"
+        },
         expected_output=[
             "miller_center$02_john_adams_3_domestic-affairs.txt$505",
             "wikipedia$john_adams.txt$51038",
@@ -75,8 +89,10 @@ CASES_SEMANTIC = [
     ),
     Case(
         name="semantic_09",
-        # Who advocated for the citizenship of native americans during his inaugural address?
         inputs="president native american citizenship inaugural address",
+        metadata={
+            "full_Q": "Who advocated for the citizenship of native americans during his inaugural address?"
+        },
         expected_output=[
             "miller_center$18_ulysses_s_grant_3_domestic-affairs.txt$8749",
             "wikipedia$ulysses_s_grant.txt$45911",
@@ -84,8 +100,10 @@ CASES_SEMANTIC = [
     ),
     Case(
         name="semantic_10",
-        # Which president was accused of being elitist due to his son traveling to Europe and meeting with royalty?
         inputs="president elitist son europe royalty",
+        metadata={
+            "full_Q": "Which president was accused of being elitist due to his son traveling to Europe and meeting with royalty?"
+        },
         expected_output=[
             "miller_center$08_martin_van_buren_6_family-life.txt$747",
         ],
@@ -96,16 +114,18 @@ CASES_SEMANTIC = [
 CASES_LEXICAL = [
     Case(
         name="lexical_01",
-        # Which president went to Plymouth elementary school?
         inputs="president plymouth elementary school",
+        metadata={
+            "full_Q": "Which president went to Plymouth elementary school?"
+        },
         expected_output=[
             "miller_center$30_calvin_coolidge_1_life-before-the-presidency.txt$392",
         ],
     ),
     Case(
         name="lexical_02",
-        # Which president signed the Kellogg-Briand Pact?
         inputs="kellogg-briand pact signed president",
+        metadata={"full_Q": "Which president signed the Kellogg-Briand Pact?"},
         expected_output=[
             "miller_center$30_calvin_coolidge_4_foreign-affairs.txt$1062",
             "miller_center$30_calvin_coolidge_0_life-in-brief.txt$4045",
@@ -114,16 +134,20 @@ CASES_LEXICAL = [
     ),
     Case(
         name="lexical_03",
-        # Who was almost forced to resign on September 11, 1841?
         inputs="forced resign september 11 1841",
+        metadata={
+            "full_Q": "Who was almost forced to resign on September 11, 1841?"
+        },
         expected_output=[
             "wikipedia$john_tyler.txt$38479",
         ],
     ),
     Case(
         name="lexical_04",
-        # Which organization that opposed overseas territorial expansion of the United States did Mark Twain and Andrew Carnegie belong to?
         inputs="mark twain andrew carnegie organization opposed overseas territorial expansion",
+        metadata={
+            "full_Q": "Which organization that opposed overseas territorial expansion of the United States did Mark Twain and Andrew Carnegie belong to?"
+        },
         expected_output=[
             "miller_center$25_william_mckinley_4_foreign-affairs.txt$1042",
             "wikipedia$william_jennings_bryan.txt$18241",
@@ -131,24 +155,30 @@ CASES_LEXICAL = [
     ),
     Case(
         name="lexical_05",
-        # Who signed the Surface Mining Control and Reclamation Act?
         inputs="surface mining control and reclamation act signed",
+        metadata={
+            "full_Q": "Who signed the Surface Mining Control and Reclamation Act?"
+        },
         expected_output=[
             "miller_center$39_jimmy_carter_3_domestic-affairs.txt$4322",
         ],
     ),
     Case(
         name="lexical_06",
-        # Who did Jefferson write a letter to on September 23, 1800?
         inputs="jefferson letter september 23 1800",
+        metadata={
+            "full_Q": "Who did Jefferson write a letter to on September 23, 1800?"
+        },
         expected_output=[
             "wikipedia$thomas_jefferson.txt$97469",
         ],
     ),
     Case(
         name="lexical_07",
-        # What did the Organization of Eastern Caribbean States ask Reagan to do?
         inputs="organization eastern caribbean states ask reagan",
+        metadata={
+            "full_Q": "What did the Organization of Eastern Caribbean States ask Reagan to do?"
+        },
         expected_output=[
             "miller_center$40_ronald_reagan_4_foreign-affairs.txt$15751",
             "miller_center$40_ronald_reagan_4_foreign-affairs.txt$16349",
@@ -156,24 +186,28 @@ CASES_LEXICAL = [
     ),
     Case(
         name="lexical_08",
-        # Who wrote 'Maine and her soil, or BLOOD!'?
         inputs="maine and her soil or blood who wrote",
+        metadata={"full_Q": "Who wrote 'Maine and her soil, or BLOOD!'?"},
         expected_output=[
             "wikipedia$martin_van_buren.txt$41446",
         ],
     ),
     Case(
         name="lexical_09",
-        # Who believed the ghost of assassinated president William McKinley had directed him to kill Roosevelt?
         inputs="ghost william mckinley directed kill roosevelt",
+        metadata={
+            "full_Q": "Who believed the ghost of assassinated president William McKinley had directed him to kill Roosevelt?"
+        },
         expected_output=[
             "wikipedia$theodore_roosevelt.txt$69119",
         ],
     ),
     Case(
         name="lexical_10",
-        # Which president had a brother Vivian and sister Mary Jane?
         inputs="president brother vivian sister mary jane",
+        metadata={
+            "full_Q": "Which president had a brother Vivian and sister Mary Jane?"
+        },
         expected_output=[
             "miller_center$33_harry_s_truman_1_life-before-the-presidency.txt$0",
             "miller_center$33_harry_s_truman_1_life-before-the-presidency.txt$2028",
@@ -187,8 +221,7 @@ CASES_LEXICAL = [
 
 retrieval_dataset = Dataset[str, list[str]](
     name="retrieval",
-    # cases=CASES_SEMANTIC + CASES_LEXICAL,
-    cases=CASES_SEMANTIC,
+    cases=CASES_SEMANTIC + CASES_LEXICAL,
     evaluators=[
         RecallAtK(k=10),
         PrecisionAtK(k=10),

--- a/evals/datasets/dataset_retrieval.py
+++ b/evals/datasets/dataset_retrieval.py
@@ -4,6 +4,18 @@ from pydantic_evals import Case, Dataset
 
 from evals.evaluators import HitAtK, PrecisionAtK, RecallAtK
 
+# Each case's `inputs` is a short, search-engine-style query: the string used for
+# both vector retrieval and reranking during evals. `metadata["full_Q"]` preserves
+# the original natural-language question that case was written to answer.
+#
+# We evaluate on rephrased queries rather than full questions because that mirrors
+# production: users ask questions in ordinary language, but the agent is instructed
+# to rewrite each question into one or more direct retrieval queries before searching
+# the knowledge base. Those rewritten queries—not the user's wording—are what drive
+# both the initial vector search and the reranking step. Short, keyword-focused
+# queries also tend to align better with how facts are expressed in the corpus,
+# improving the odds of surfacing the right chunks.
+
 CASES_SEMANTIC = [
     Case(
         name="semantic_01",

--- a/evals/datasets/dataset_retrieval.py
+++ b/evals/datasets/dataset_retrieval.py
@@ -4,18 +4,22 @@ from pydantic_evals import Case, Dataset
 
 from evals.evaluators import HitAtK, PrecisionAtK, RecallAtK
 
-retrieval_dataset = Dataset[str, list[int]](
+retrieval_dataset = Dataset[str, list[str]](
     name="retrieval",
     cases=[
         Case(
             name="case_01",
             inputs="Who did Lincoln promote after learning he had no presidential ambitions?",
-            expected_output=[108],
+            expected_output=[
+                "wikipedia$abraham_lincoln.txt$55825"
+            ],  # TODO: Verify this output
         ),
         Case(
             name="case_02",
             inputs="How did Andrew Jackson's wife die?",
-            expected_output=[275],
+            expected_output=[
+                "wikipedia$andrew_jackson.txt$28233"
+            ],  # TODO: Verify this output
         ),
     ],
     evaluators=[

--- a/evals/datasets/dataset_retrieval.py
+++ b/evals/datasets/dataset_retrieval.py
@@ -96,14 +96,16 @@ CASES_SEMANTIC = [
 CASES_LEXICAL = [
     Case(
         name="lexical_01",
-        inputs="Which president went to Plymouth elementary school?",
+        # Which president went to Plymouth elementary school?
+        inputs="president plymouth elementary school",
         expected_output=[
             "miller_center$30_calvin_coolidge_1_life-before-the-presidency.txt$392",
         ],
     ),
     Case(
         name="lexical_02",
-        inputs="Which president signed the Kellogg-Briand Pact?",
+        # Which president signed the Kellogg-Briand Pact?
+        inputs="kellogg-briand pact signed president",
         expected_output=[
             "miller_center$30_calvin_coolidge_4_foreign-affairs.txt$1062",
             "miller_center$30_calvin_coolidge_0_life-in-brief.txt$4045",
@@ -112,14 +114,16 @@ CASES_LEXICAL = [
     ),
     Case(
         name="lexical_03",
-        inputs="Who was almost forced to resign on September 11, 1841?",
+        # Who was almost forced to resign on September 11, 1841?
+        inputs="forced resign september 11 1841",
         expected_output=[
             "wikipedia$john_tyler.txt$38479",
         ],
     ),
     Case(
         name="lexical_04",
-        inputs="Which organization that opposed overseas territorial expansion of the United States did Mark Twain and Andrew Carnegie belong to?",
+        # Which organization that opposed overseas territorial expansion of the United States did Mark Twain and Andrew Carnegie belong to?
+        inputs="mark twain andrew carnegie organization opposed overseas territorial expansion",
         expected_output=[
             "miller_center$25_william_mckinley_4_foreign-affairs.txt$1042",
             "wikipedia$william_jennings_bryan.txt$18241",
@@ -127,21 +131,24 @@ CASES_LEXICAL = [
     ),
     Case(
         name="lexical_05",
-        inputs="Who signed the Surface Mining Control and Reclamation Act?",
+        # Who signed the Surface Mining Control and Reclamation Act?
+        inputs="surface mining control and reclamation act signed",
         expected_output=[
             "miller_center$39_jimmy_carter_3_domestic-affairs.txt$4322",
         ],
     ),
     Case(
         name="lexical_06",
-        inputs="Who did Jefferson write a letter to on September 23, 1800?",
+        # Who did Jefferson write a letter to on September 23, 1800?
+        inputs="jefferson letter september 23 1800",
         expected_output=[
             "wikipedia$thomas_jefferson.txt$97469",
         ],
     ),
     Case(
         name="lexical_07",
-        inputs="What did the Organization of Eastern Caribbean States ask Reagan to do?",
+        # What did the Organization of Eastern Caribbean States ask Reagan to do?
+        inputs="organization eastern caribbean states ask reagan",
         expected_output=[
             "miller_center$40_ronald_reagan_4_foreign-affairs.txt$15751",
             "miller_center$40_ronald_reagan_4_foreign-affairs.txt$16349",
@@ -149,21 +156,24 @@ CASES_LEXICAL = [
     ),
     Case(
         name="lexical_08",
-        inputs="Who wrote 'Maine and her soil, or BLOOD!'?",
+        # Who wrote 'Maine and her soil, or BLOOD!'?
+        inputs="maine and her soil or blood who wrote",
         expected_output=[
             "wikipedia$martin_van_buren.txt$41446",
         ],
     ),
     Case(
         name="lexical_09",
-        inputs="Who believed the ghost of assassinated president William McKinley had directed him to kill Roosevelt?",
+        # Who believed the ghost of assassinated president William McKinley had directed him to kill Roosevelt?
+        inputs="ghost william mckinley directed kill roosevelt",
         expected_output=[
             "wikipedia$theodore_roosevelt.txt$69119",
         ],
     ),
     Case(
         name="lexical_10",
-        inputs="Which president had a brother Vivian and sister Mary Jane?",
+        # Which president had a brother Vivian and sister Mary Jane?
+        inputs="president brother vivian sister mary jane",
         expected_output=[
             "miller_center$33_harry_s_truman_1_life-before-the-presidency.txt$0",
             "miller_center$33_harry_s_truman_1_life-before-the-presidency.txt$2028",

--- a/evals/datasets/dataset_retrieval.py
+++ b/evals/datasets/dataset_retrieval.py
@@ -239,8 +239,10 @@ retrieval_dataset = Dataset[str, list[str]](
     name="retrieval",
     cases=CASES_SEMANTIC + CASES_LEXICAL,
     evaluators=[
-        RecallAtK(k=10),
-        PrecisionAtK(k=10),
+        HitAtK(k=1),
         HitAtK(k=10),
+        HitAtK(k=20),
+        RecallAtK(k=10),
+        RecallAtK(k=20),
     ],
 )

--- a/evals/datasets/dataset_retrieval.py
+++ b/evals/datasets/dataset_retrieval.py
@@ -7,35 +7,40 @@ from evals.evaluators import HitAtK, PrecisionAtK, RecallAtK
 CASES_SEMANTIC = [
     Case(
         name="semantic_01",
-        inputs="Who did Lincoln promote after learning he had no presidential ambitions?",
+        # Who did Lincoln promote after learning he had no presidential ambitions?
+        inputs="lincoln who promoted no presidential ambitions",
         expected_output=[
             "wikipedia$abraham_lincoln.txt$55825",
         ],
     ),
     Case(
         name="semantic_02",
-        inputs="How did Andrew Jackson's wife die?",
+        # How did Andrew Jackson's wife die?
+        inputs="andrew jackson wife death",
         expected_output=[
             "wikipedia$andrew_jackson.txt$28233",
         ],
     ),
     Case(
         name="semantic_03",
-        inputs="Which president was married to a woman whose death was potentially caused by rumors that she cheated on her previous husband?",
+        # Which president was married to a woman whose death was potentially caused by rumors that she cheated on her previous husband?
+        inputs="president wife died rumors cheating previous husband",
         expected_output=[
             "wikipedia$andrew_jackson.txt$28233",
         ],
     ),
     Case(
         name="semantic_04",
-        inputs="Who was almost ousted from the presidency in the middle of the nineteenth century due to his cabinet members all quitting in a staged, organized manner?",
+        # Who was almost ousted from the presidency in the middle of the nineteenth century due to his cabinet members all quitting in a staged, organized manner?
+        inputs="19th century president cabinet all resigned sequentially",
         expected_output=[
             "wikipedia$john_tyler.txt$38479",
         ],
     ),
     Case(
         name="semantic_05",
-        inputs="Who did not actively (but perhaps did passively) seek a 2nd term because he knew he had a terminal illness?",
+        # Who did not actively (but perhaps did passively) seek a 2nd term because he knew he had a terminal illness?
+        inputs="president terminal illness second term reelection",
         expected_output=[
             "miller_center$21_chester_a_arthur_5_life-after-the-presidency.txt$0",
             "miller_center$21_chester_a_arthur_2_campaigns-and-elections.txt$3476",
@@ -43,7 +48,8 @@ CASES_SEMANTIC = [
     ),
     Case(
         name="semantic_06",
-        inputs="Who sent a military force to China to save diplomats from a violent group of rebels who had killed Christians?",
+        # Who sent a military force to China to save diplomats from a violent group of rebels who had killed Christians?
+        inputs="military force china save diplomats rebels killed christians",
         expected_output=[
             "miller_center$25_william_mckinley_4_foreign-affairs.txt$8642",
             "miller_center$25_william_mckinley_0_life-in-brief.txt$3081",
@@ -52,14 +58,16 @@ CASES_SEMANTIC = [
     ),
     Case(
         name="semantic_07",
-        inputs="Which action taken by the USSR regarding a commercial jet from an east asian nation resulted in the deaths of nearly three hundred civilians?",
+        # Which action taken by the USSR regarding a commercial jet from an east asian nation resulted in the deaths of nearly three hundred civilians?
+        inputs="ussr commercial jet east asia 300 civilians killed",
         expected_output=[
             "miller_center$40_ronald_reagan_4_foreign-affairs.txt$11546",
         ],
     ),
     Case(
         name="semantic_08",
-        inputs="What was the act that Adams signed into law whose passage was facilitated by anti-French feelings after a foreign controversy?",
+        # What was the act that Adams signed into law whose passage was facilitated by anti-French feelings after a foreign controversy?
+        inputs="john adams act signed anti-french foreign controversy",
         expected_output=[
             "miller_center$02_john_adams_3_domestic-affairs.txt$505",
             "wikipedia$john_adams.txt$51038",
@@ -67,7 +75,8 @@ CASES_SEMANTIC = [
     ),
     Case(
         name="semantic_09",
-        inputs="Who advocated for the citizenship of native americans during his inaugural address?",
+        # Who advocated for the citizenship of native americans during his inaugural address?
+        inputs="president native american citizenship inaugural address",
         expected_output=[
             "miller_center$18_ulysses_s_grant_3_domestic-affairs.txt$8749",
             "wikipedia$ulysses_s_grant.txt$45911",
@@ -75,7 +84,8 @@ CASES_SEMANTIC = [
     ),
     Case(
         name="semantic_10",
-        inputs="Which president was accused of being elitist due to his son traveling to Europe and meeting with royalty?",
+        # Which president was accused of being elitist due to his son traveling to Europe and meeting with royalty?
+        inputs="president elitist son europe royalty",
         expected_output=[
             "miller_center$08_martin_van_buren_6_family-life.txt$747",
         ],
@@ -165,18 +175,10 @@ CASES_LEXICAL = [
     ),
 ]
 
-
-# A case for generation evals
-# Case(
-#     name="multihop_01",
-#     inputs="On what date was the president that Mark Twain helped via a generous book deal born?",
-#     expected_output="April 27, 1822",
-# ),
-
-
 retrieval_dataset = Dataset[str, list[str]](
     name="retrieval",
-    cases=CASES_SEMANTIC + CASES_LEXICAL,
+    # cases=CASES_SEMANTIC + CASES_LEXICAL,
+    cases=CASES_SEMANTIC,
     evaluators=[
         RecallAtK(k=10),
         PrecisionAtK(k=10),

--- a/evals/evaluators.py
+++ b/evals/evaluators.py
@@ -109,6 +109,7 @@ DEFAULT_FAITHFULNESS_RUBRIC = (
     "documents. Claims that rely on general knowledge outside the retrieved "
     "documents should fail."
 )
+# TODO: Tune these to correctly score unanswerable questions (if necessary)
 
 
 @dataclass

--- a/evals/evaluators.py
+++ b/evals/evaluators.py
@@ -98,18 +98,23 @@ def _grading_to_reason(grading: GradingOutput) -> EvaluationReason:
 
 
 DEFAULT_RELEVANCE_RUBRIC = (
-    "The response directly addresses the question that was asked."
+    "The response directly addresses the question that was asked. "
+    "If the response states that the available information is insufficient to answer "
+    "(e.g. it does not know, or the knowledge base does not contain the answer), that "
+    "counts as addressing the question."
 )
 DEFAULT_CORRECTNESS_RUBRIC = (
     "The response is factually correct and consistent with the expected key "
     "facts. Minor wording differences are acceptable."
 )
 DEFAULT_FAITHFULNESS_RUBRIC = (
-    "Every factual claim in the response is supported by the retrieved "
-    "documents. Claims that rely on general knowledge outside the retrieved "
-    "documents should fail."
+    "Every factual claim in the response must be supported by the retrieved documents. "
+    "Claims drawn from general knowledge or speculation beyond the retrieved documents "
+    "fail. If the response declines to answer because the retrieved documents do not support "
+    "an answer, pass when it makes no unsupported factual claims about the subject. "
+    "Meta-statements about insufficient evidence (e.g. 'the documents don't say') do "
+    "not need to be literally quoted from a chunk."
 )
-# TODO: Tune these to correctly score unanswerable questions (if necessary)
 
 
 @dataclass

--- a/evals/evaluators.py
+++ b/evals/evaluators.py
@@ -24,24 +24,24 @@ from evals.schemas import GenerationResult
 
 
 def _hits_at_k(
-    ranked_chunk_ids: list[int],
-    relevant_chunk_ids: list[int] | None,
+    ranked_chunk_keys: list[str],
+    relevant_chunk_keys: list[str] | None,
     k: int,
 ) -> tuple[int, int]:
     """Return the number of relevant hits and the size of the gold set."""
-    relevant = set(relevant_chunk_ids or [])
-    top_k_ids = set(ranked_chunk_ids[:k])
-    return len(relevant & top_k_ids), len(relevant)
+    relevant = set(relevant_chunk_keys or [])
+    top_k_keys = set(ranked_chunk_keys[:k])
+    return len(relevant & top_k_keys), len(relevant)
 
 
 @dataclass
-class RecallAtK(Evaluator[str, list[int]]):
+class RecallAtK(Evaluator[str, list[str]]):
     k: int
 
     def get_default_evaluation_name(self) -> str:
         return f"recall@{self.k}"
 
-    def evaluate(self, ctx: EvaluatorContext[str, list[int]]) -> float:
+    def evaluate(self, ctx: EvaluatorContext[str, list[str]]) -> float:
         hits, num_relevant = _hits_at_k(
             ctx.output, ctx.expected_output, self.k
         )
@@ -51,25 +51,25 @@ class RecallAtK(Evaluator[str, list[int]]):
 
 
 @dataclass
-class PrecisionAtK(Evaluator[str, list[int]]):
+class PrecisionAtK(Evaluator[str, list[str]]):
     k: int
 
     def get_default_evaluation_name(self) -> str:
         return f"precision@{self.k}"
 
-    def evaluate(self, ctx: EvaluatorContext[str, list[int]]) -> float:
+    def evaluate(self, ctx: EvaluatorContext[str, list[str]]) -> float:
         hits, _ = _hits_at_k(ctx.output, ctx.expected_output, self.k)
         return hits / self.k
 
 
 @dataclass
-class HitAtK(Evaluator[str, list[int]]):
+class HitAtK(Evaluator[str, list[str]]):
     k: int
 
     def get_default_evaluation_name(self) -> str:
         return f"hit@{self.k}"
 
-    def evaluate(self, ctx: EvaluatorContext[str, list[int]]) -> bool:
+    def evaluate(self, ctx: EvaluatorContext[str, list[str]]) -> bool:
         hits, num_relevant = _hits_at_k(
             ctx.output, ctx.expected_output, self.k
         )

--- a/evals/evaluators.py
+++ b/evals/evaluators.py
@@ -104,8 +104,8 @@ DEFAULT_RELEVANCE_RUBRIC = (
     "counts as addressing the question."
 )
 DEFAULT_CORRECTNESS_RUBRIC = (
-    "The response is factually correct and consistent with the expected key "
-    "facts. Minor wording differences are acceptable."
+    "The response is correct because it is consistent with the expected answer. "
+    "Minor wording differences are acceptable."
 )
 DEFAULT_FAITHFULNESS_RUBRIC = (
     "Every factual claim in the response must be supported by the retrieved documents. "

--- a/evals/run_eval_generation.py
+++ b/evals/run_eval_generation.py
@@ -5,6 +5,7 @@ import sys
 
 import logfire
 from dotenv import load_dotenv
+from pydantic_ai import Agent
 
 from evals.datasets.dataset_generation import generation_dataset
 from evals.tasks import make_generation_task
@@ -41,6 +42,10 @@ def main() -> None:
         service_name="presidents-rag-evals",
         environment="dev",
     )
+    # Instrument every pydantic_ai Agent, including the internal judge agents
+    # used by pydantic_evals' LLM-as-a-judge helpers, so their token usage and
+    # cost show up in the Logfire UI.
+    Agent.instrument_all()
 
     args = parse_args()
     task = make_generation_task(

--- a/evals/run_eval_generation.py
+++ b/evals/run_eval_generation.py
@@ -13,6 +13,12 @@ from evals.tasks import make_generation_task
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run generation evals.")
     parser.add_argument(
+        "--model",
+        "-m",
+        required=True,
+        help="Pydantic AI model string for the agent (e.g. openai:gpt-5.4-mini).",
+    )
+    parser.add_argument(
         "--top-k-retrieval",
         "-k1",
         type=int,
@@ -37,10 +43,15 @@ def main() -> None:
     )
 
     args = parse_args()
-    task = make_generation_task(args.top_k_retrieval, args.top_k_rerank)
+    task = make_generation_task(
+        args.model,
+        args.top_k_retrieval,
+        args.top_k_rerank,
+    )
     report = generation_dataset.evaluate_sync(
         task,
         metadata={
+            "model": args.model,
             "top_k_retrieval": args.top_k_retrieval,
             "top_k_rerank": args.top_k_rerank,
         },

--- a/evals/run_eval_retrieval.py
+++ b/evals/run_eval_retrieval.py
@@ -26,6 +26,11 @@ def parse_args() -> argparse.Namespace:
         dest="top_k_rerank",
         help="Number of chunks to keep after reranking.",
     )
+    parser.add_argument(
+        "--notes",
+        "-n",
+        help="Free-text notes about this eval run (stored in report metadata).",
+    )
     return parser.parse_args()
 
 
@@ -43,6 +48,7 @@ def main() -> None:
         metadata={
             "top_k_retrieval": args.top_k_retrieval,
             "top_k_rerank": args.top_k_rerank,
+            "notes": args.notes,
         },
     )
     report.print()

--- a/evals/run_eval_retrieval.py
+++ b/evals/run_eval_retrieval.py
@@ -5,6 +5,7 @@ import sys
 
 import logfire
 from dotenv import load_dotenv
+from pydantic_ai import Agent
 
 from evals.datasets.dataset_retrieval import retrieval_dataset
 from evals.tasks import make_retrieval_task
@@ -40,6 +41,10 @@ def main() -> None:
         service_name="presidents-rag-evals",
         environment="dev",
     )
+    # Instrument every pydantic_ai Agent, including the internal judge agents
+    # used by pydantic_evals' LLM-as-a-judge helpers, so their token usage and
+    # cost show up in the Logfire UI.
+    Agent.instrument_all()
 
     args = parse_args()
     task = make_retrieval_task(args.top_k_retrieval, args.top_k_rerank)

--- a/evals/tasks.py
+++ b/evals/tasks.py
@@ -31,6 +31,7 @@ def make_retrieval_task(
 
 
 def make_generation_task(
+    model: str,
     top_k_retrieval: int,
     top_k_rerank: int,
 ) -> Callable[[str], GenerationResult]:
@@ -46,6 +47,7 @@ def make_generation_task(
         result = agent.run_sync(
             query,
             deps=deps,
+            model=model,
             usage_limits=UsageLimits(request_limit=REQUEST_LIMIT),
         )
         answer, cited_chunks = parse_agent_run(result, deps)

--- a/evals/tasks.py
+++ b/evals/tasks.py
@@ -6,7 +6,7 @@ from pydantic_ai.usage import UsageLimits
 
 from backend.schemas import chunk_key
 from evals.schemas import GenerationResult
-from frontend.agent import REQUEST_LIMIT, AgentDeps, agent, parse_agent_run
+from frontend.agent import AgentDeps, agent, parse_agent_run
 from frontend.client import RAGClient
 
 
@@ -48,7 +48,7 @@ def make_generation_task(
             query,
             deps=deps,
             model=model,
-            usage_limits=UsageLimits(request_limit=REQUEST_LIMIT),
+            usage_limits=UsageLimits(request_limit=5),
         )
         answer, cited_chunks = parse_agent_run(result, deps)
         return GenerationResult(

--- a/evals/tasks.py
+++ b/evals/tasks.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 
 from pydantic_ai.usage import UsageLimits
 
+from backend.schemas import chunk_key
 from evals.schemas import GenerationResult
 from frontend.agent import REQUEST_LIMIT, AgentDeps, agent, parse_agent_run
 from frontend.client import RAGClient
@@ -12,16 +13,19 @@ from frontend.client import RAGClient
 def make_retrieval_task(
     top_k_retrieval: int,
     top_k_rerank: int,
-) -> Callable[[str], list[int]]:
-    """Return a task that runs retrieve → rerank for a single query."""
+) -> Callable[[str], list[str]]:
+    """Return a task that runs retrieve → rerank for a single query.
+
+    Chunks are identified by a stable ``source$document$start_index`` key so
+    gold labels stay valid across embedding models (whose DB primary keys
+    differ for the same logical chunk).
+    """
     rag_client = RAGClient()
 
-    def task(query: str) -> list[int]:
+    def task(query: str) -> list[str]:
         chunks = rag_client.retrieve(query, top_k=top_k_retrieval)
         ranked = rag_client.rerank(query, chunks, top_k_rerank)
-        return [
-            chunk.chunk_id for chunk in ranked if chunk.chunk_id is not None
-        ]
+        return [chunk_key(chunk) for chunk in ranked]
 
     return task
 

--- a/frontend/agent.py
+++ b/frontend/agent.py
@@ -110,7 +110,10 @@ agent = Agent(
     model=MODEL,
     deps_type=AgentDeps,
     output_type=AgentResponse,
-    model_settings=ModelSettings(parallel_tool_calls=False),
+    model_settings=ModelSettings(
+        parallel_tool_calls=False,  # Agent is synchronous atm
+        thinking="low",
+    ),
     system_prompt=SYSTEM_PROMPT,
     capabilities=[Instrumentation()],
 )

--- a/frontend/agent.py
+++ b/frontend/agent.py
@@ -47,11 +47,14 @@ How to work:
 - For questions that compare or aggregate independent facts, search for each
   fact separately, then combine the results.
 - Inspect what you get back. If the chunks don't actually support an answer,
-  rewrite your query and search again. If after reasonable effort the knowledge
-  base still doesn't contain the answer, say you don't know rather than guessing.
+  rewrite your query and search again, but only up to 3 times. If after reasonable
+  effort (up to 3 searches using the search_knowledge_base tool), the knowledge
+  base still doesn't contain the answer, stop searching and say you don't
+  know rather than guessing.
 
 Final answer:
-- Ground your answer strictly in the retrieved chunks.
+- Ground your answer strictly in the retrieved chunks. Hallucinating answers
+  is strictly forbidden.
 - Set `supporting_chunk_ids` to the `chunk_id`s of the chunks that actually
   support your answer (omit chunks you retrieved but didn't rely on).
 """.strip()

--- a/frontend/agent.py
+++ b/frontend/agent.py
@@ -113,6 +113,7 @@ agent = Agent(
     model_settings=ModelSettings(
         parallel_tool_calls=False,  # Agent is synchronous atm
         thinking="medium",
+        max_tokens=20_000,  # must exceed Anthropic thinking budget
     ),
     system_prompt=SYSTEM_PROMPT,
     capabilities=[Instrumentation()],

--- a/frontend/agent.py
+++ b/frontend/agent.py
@@ -112,7 +112,7 @@ agent = Agent(
     output_type=AgentResponse,
     model_settings=ModelSettings(
         parallel_tool_calls=False,  # Agent is synchronous atm
-        thinking="low",
+        thinking="medium",
     ),
     system_prompt=SYSTEM_PROMPT,
     capabilities=[Instrumentation()],


### PR DESCRIPTION
## Summary

Overhauls the eval suite so retrieval and generation benchmarks are larger, more realistic, and stable across embedding models. Also tightens agent behavior and judge configuration for more reliable scoring.

## Changes

### Stable retrieval gold labels
Retrieval evals no longer key gold labels on database `chunk_id`s (which change when the embedding model changes). Gold labels now use a stable `source$document$start_index` key via a new `chunk_key()` helper in `backend/schemas.py`.

### Expanded datasets
- **Retrieval** (2 → 20 cases): 10 semantic and 10 lexical cases. Each case uses a short, search-engine-style query as `inputs` (mirroring how the agent rewrites questions before retrieval), with the original question preserved in `metadata["full_question"]`.
- **Generation** (2 → 15 cases): 5 single-hop, 5 multi-hop, and 5 unanswerable cases to exercise refusal behavior.

### Retrieval metrics
Dropped `precision@k`; evaluators now report only `hit@k` and `recall@k`.

### Judge and rubric improvements
- Sharpened relevance, correctness, and faithfulness rubrics, including explicit guidance for unanswerable questions (e.g. “I don’t know” should pass relevance/correctness when appropriate; faithfulness should not require literal quotes for meta-statements about insufficient evidence).
- Judge model set to `gpt-5.4-mini` with `thinking="high"` and `temperature=0`.

### Eval runner improvements
- **Generation evals**: required `--model` flag so different agent models can be compared; model name stored in report metadata.
- **Retrieval evals**: optional `--notes` flag for annotating runs.
- Both runners call `Agent.instrument_all()` so judge token usage and cost appear in Logfire.

### Agent behavior (`frontend/agent.py`)
- System prompt caps search retries at 3 and explicitly forbids hallucination.
- Default model settings: `thinking="medium"`, `max_tokens=20_000`.
- Generation eval task uses `request_limit=5`.

## Test plan

- [x] Run retrieval evals: `python -m evals.run_eval_retrieval`
- [x] Run generation evals with a model: `python -m evals.run_eval_generation --model openai:gpt-5.4-mini`
- [x] Confirm retrieval gold labels resolve correctly against current chunks (stable keys match expected `source$document$start_index` values)
- [x] Spot-check unanswerable generation cases — agent should refuse rather than guess
- [x] Verify judge costs appear in Logfire after a generation eval run